### PR TITLE
fix(gamification): derive level from totalXP on the sync path

### DIFF
--- a/src/components/gamification/XPProgressBar.tsx
+++ b/src/components/gamification/XPProgressBar.tsx
@@ -15,11 +15,13 @@ export function XPProgressBar({ compact = false }: XPProgressBarProps) {
     getXPProgress,
     getLevelTitle,
     getStreakMultiplier,
+    isMaxLevel,
   } = useGamificationStore()
 
   const xpNeeded = getXPForNextLevel()
   const progress = getXPProgress()
   const multiplier = getStreakMultiplier()
+  const maxLevel = isMaxLevel()
 
   if (compact) {
     return (
@@ -74,7 +76,11 @@ export function XPProgressBar({ compact = false }: XPProgressBarProps) {
       {/* XP text */}
       <div className="flex justify-between text-xs text-np-text-secondary font-mono">
         <span>{formatXP(currentXP)} XP</span>
-        <span>{formatXP(xpNeeded)} {t('gamification.toNextLevel')}</span>
+        {maxLevel ? (
+          <span>{t('gamification.maxLevelReached')}</span>
+        ) : (
+          <span>{formatXP(xpNeeded)} {t('gamification.toNextLevel')}</span>
+        )}
       </div>
     </div>
   )

--- a/src/components/layout/MenuBar.tsx
+++ b/src/components/layout/MenuBar.tsx
@@ -3,6 +3,7 @@ import { useUIStore } from '../../stores/uiStore'
 import { useChatStore } from '../../stores/chatStore'
 import { useSettingsStore, PROVIDER_INFO } from '../../stores/settingsStore'
 import { useGamificationStore, LEVELS, ACHIEVEMENTS, formatXP } from '../../stores/gamificationStore'
+import { useTranslation } from '../../i18n'
 
 interface MenuBarProps {
   onSettingsClick?: () => void
@@ -44,6 +45,7 @@ const handleClose = () => {
 }
 
 export function MenuBar({ onSettingsClick }: MenuBarProps) {
+  const { t } = useTranslation()
   const { toggleFocusMode } = useUIStore()
   const { toggleOpen: toggleChat } = useChatStore()
   const { llmProvider, apiKeys } = useSettingsStore()
@@ -59,11 +61,13 @@ export function MenuBar({ onSettingsClick }: MenuBarProps) {
     getXPProgress,
     getXPForNextLevel,
     getLevelTitle,
+    isMaxLevel,
   } = useGamificationStore()
 
   const xpProgress = getXPProgress()
   const xpForNext = getXPForNextLevel()
   const levelTitle = getLevelTitle()
+  const maxLevel = isMaxLevel()
   const unlockedAchievements = ACHIEVEMENTS.filter(a => achievements.includes(a.id))
 
   // Check if API key is configured
@@ -148,7 +152,14 @@ export function MenuBar({ onSettingsClick }: MenuBarProps) {
                     <div className="flex items-center gap-2">
                       <span className="text-2xl">🎮</span>
                       <div>
-                        <div className="text-np-text-primary font-bold">Level {level}</div>
+                        <div className="text-np-text-primary font-bold flex items-center gap-1">
+                          Level {level}
+                          {maxLevel && (
+                            <span className="text-[10px] px-1 py-0.5 rounded bg-np-purple/20 text-np-purple">
+                              {t('gamification.maxLevel')}
+                            </span>
+                          )}
+                        </div>
                         <div className="text-xs text-np-purple">{levelTitle}</div>
                       </div>
                     </div>
@@ -163,7 +174,11 @@ export function MenuBar({ onSettingsClick }: MenuBarProps) {
                   <div className="mt-2">
                     <div className="flex justify-between text-xs text-np-text-secondary mb-1">
                       <span>{formatXP(currentXP)} XP</span>
-                      <span>{formatXP(xpForNext)} XP to next</span>
+                      {maxLevel ? (
+                        <span>{t('gamification.maxLevelReached')}</span>
+                      ) : (
+                        <span>{formatXP(xpForNext)} XP to next</span>
+                      )}
                     </div>
                     <div className="h-2 bg-np-bg-tertiary rounded-full overflow-hidden">
                       <div

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -353,6 +353,8 @@
         "stats": "Your Stats",
         "totalXP": "Total XP",
         "toNextLevel": "to next level",
+        "maxLevel": "MAX",
+        "maxLevelReached": "Max level reached",
         "streak": "Streak (current/best)",
         "activity": "Activity",
         "tasksCompleted": "Tasks Completed",

--- a/src/i18n/tr.json
+++ b/src/i18n/tr.json
@@ -353,6 +353,8 @@
         "stats": "İstatistikler",
         "totalXP": "Toplam XP",
         "toNextLevel": "sonraki seviyeye",
+        "maxLevel": "MAKS",
+        "maxLevelReached": "Maksimum seviyeye ulaşıldı",
         "streak": "Seri (mevcut/en iyi)",
         "activity": "Aktivite",
         "tasksCompleted": "Tamamlanan Görevler",

--- a/src/services/gistSyncService.ts
+++ b/src/services/gistSyncService.ts
@@ -9,7 +9,7 @@ import { useJournalStore } from '../stores/journalStore'
 import { useBookmarkStore } from '../stores/bookmarkStore'
 import { useDailyNotesStore } from '../stores/dailyNotesStore'
 import { useFocusStore } from '../stores/focusStore'
-import { useGamificationStore } from '../stores/gamificationStore'
+import { useGamificationStore, deriveLevelAndXP } from '../stores/gamificationStore'
 import { useIdeaStore } from '../stores/ideaStore'
 
 const GIST_FILENAME = 'bytepad-data.json'
@@ -196,16 +196,23 @@ function applyData(syncData: SyncData, forceOverwrite: boolean = false): void {
     }
     if (data.gamification) {
         const currentGamification = useGamificationStore.getState()
-        // Check if gamification data changed
-        const gamificationChanged =
-            currentGamification.level !== data.gamification.level ||
-            currentGamification.currentXP !== data.gamification.currentXP ||
-            currentGamification.totalXP !== data.gamification.totalXP
+        // `level`/`currentXP` are derived values (see deriveLevelAndXP), not independent
+        // source-of-truth fields — comparing them here would make this dirty-check fire
+        // against a peer device that hasn't picked up a level-table change yet (its stored
+        // `level` differs from ours even though the underlying `totalXP` doesn't), causing
+        // the two devices to flap the remote blob back and forth on every sync. `totalXP` is
+        // the only value we trust verbatim, so that's the only one worth comparing.
+        const gamificationChanged = currentGamification.totalXP !== data.gamification.totalXP
 
         if (gamificationChanged) {
+            // Never trust a remote `level`/`currentXP` verbatim — always re-derive them from
+            // `totalXP` through the same helper the persist `merge` uses, so a stale blob
+            // (e.g. from a device that hasn't picked up a level-table change) can't push a
+            // wrong level back into this store.
+            const { level, currentXP } = deriveLevelAndXP(data.gamification.totalXP)
             updates.push(() => useGamificationStore.setState({
-                level: data.gamification!.level,
-                currentXP: data.gamification!.currentXP,
+                level,
+                currentXP,
                 totalXP: data.gamification!.totalXP,
                 tasksCompleted: data.gamification!.tasksCompleted,
                 tasksCompletedToday: data.gamification!.tasksCompletedToday,

--- a/src/stores/gamificationStore.ts
+++ b/src/stores/gamificationStore.ts
@@ -189,6 +189,7 @@ interface GamificationState extends UserStats {
   getXPProgress: () => number // 0-100 percentage
   getStreakMultiplier: () => number
   getLevelTitle: () => string
+  isMaxLevel: () => boolean
 }
 
 const getDateString = (date: Date = new Date()) => {
@@ -203,6 +204,19 @@ const calculateLevel = (totalXP: number): number => {
   }
   return 1
 }
+
+// Single source of truth for what `level`/`currentXP` mean given `totalXP`. `totalXP` is the
+// only gamification value multiple independent writers (localStorage hydration, Gist sync)
+// are allowed to trust verbatim; `level` and `currentXP` must always be re-derived from it
+// through this function rather than accepted as-is from a persisted or remote payload, so a
+// stale/foreign `level` can never be written back into the store.
+export const deriveLevelAndXP = (totalXP: number): Pick<UserStats, 'level' | 'currentXP'> => {
+  const level = calculateLevel(totalXP)
+  const levelInfo = LEVELS.find(l => l.level === level) ?? LEVELS[0]
+  return { level, currentXP: totalXP - levelInfo.xp }
+}
+
+const MAX_LEVEL = LEVELS[LEVELS.length - 1].level
 
 const getStreakMultiplier = (streakDays: number): number => {
   for (const { minDays, multiplier } of STREAK_MULTIPLIERS) {
@@ -387,6 +401,10 @@ export const useGamificationStore = create<GamificationState>()(
       getLevelTitle: () => {
         return get().getLevel().title
       },
+
+      isMaxLevel: () => {
+        return get().level >= MAX_LEVEL
+      },
     }),
     {
       name: 'bytepad-gamification',
@@ -399,8 +417,7 @@ export const useGamificationStore = create<GamificationState>()(
       migrate: (persistedState) => {
         const persisted = (persistedState ?? {}) as Partial<UserStats>
         const totalXP = typeof persisted.totalXP === 'number' ? persisted.totalXP : 0
-        const level = calculateLevel(totalXP)
-        const levelInfo = LEVELS.find(l => l.level === level) ?? LEVELS[0]
+        const { level, currentXP } = deriveLevelAndXP(totalXP)
 
         return {
           tasksCompleted: 0,
@@ -418,18 +435,20 @@ export const useGamificationStore = create<GamificationState>()(
           ...persisted,
           totalXP,
           level,
-          currentXP: totalXP - levelInfo.xp,
+          currentXP,
         }
       },
       // `migrate` above is gated by zustand on `typeof persistedVersion === 'number'`. Every
       // install that persisted state before this `version` field existed has no version key
       // at all (`undefined`), so that gate is false and `migrate` never runs for them — the
       // exact installs this fix exists for. `merge` runs on every hydration regardless of
-      // version, so recompute `level`/`currentXP` from `totalXP` here too. This is a pure
-      // function of `totalXP`, so it's a no-op when the persisted values are already correct,
-      // and it only touches level fields — every other persisted stat/achievement/streak
-      // passes through via the spread untouched. Not invoked at all when there is no
-      // persisted state (brand-new user), so defaults are left alone.
+      // version — including with `persistedState === undefined` for a brand-new install that
+      // has nothing in localStorage yet — so recompute `level`/`currentXP` from `totalXP` here
+      // too. The `if (!persisted)` branch below handles that undefined case explicitly by
+      // returning the untouched defaults. For real persisted state this is a pure function of
+      // `totalXP`, so it's a no-op when the persisted values are already correct, and it only
+      // touches level fields — every other persisted stat/achievement/streak passes through
+      // via the spread untouched.
       merge: (persistedState, currentState) => {
         const persisted = persistedState as Partial<UserStats> | null | undefined
         const merged = { ...currentState, ...persisted }
@@ -438,15 +457,18 @@ export const useGamificationStore = create<GamificationState>()(
           return merged
         }
 
-        const totalXP = typeof persisted.totalXP === 'number' ? persisted.totalXP : merged.totalXP
-        const level = calculateLevel(totalXP)
-        const levelInfo = LEVELS.find(l => l.level === level) ?? LEVELS[0]
+        // Fall back to the live store's totalXP, not `merged.totalXP` — `merged` already
+        // spread `persisted` over the defaults, so if `persisted.totalXP` were a non-number
+        // (e.g. `null`, which JSON permits), `merged.totalXP` would still be that same bad
+        // value and this guard would be a no-op.
+        const totalXP = typeof persisted.totalXP === 'number' ? persisted.totalXP : currentState.totalXP
+        const { level, currentXP } = deriveLevelAndXP(totalXP)
 
         return {
           ...merged,
           totalXP,
           level,
-          currentXP: totalXP - levelInfo.xp,
+          currentXP,
         }
       },
       partialize: (state) => ({


### PR DESCRIPTION
Routes the cloud-sync write through the same derivation the persist layer uses, so level and XP always follow from totalXP rather than being trusted from a stored value. Also adds a max-level display state and tightens a fallback.