### PR TITLE
chore(firebase): narrow access rules to the sync document

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,10 +14,12 @@ VITE_FIREBASE_APP_ID=your-app-id
 # Firebase Setup Steps:
 # 1. Go to Firebase Console and create a project
 # 2. Enable Authentication > Sign-in method > Google
-# 3. Enable Firestore Database
+# 3. Enable Firestore Database - when prompted to choose a starting mode,
+#    select "production mode" (locked). Do not start in test mode.
 # 4. Deploy the access rules from firestore.rules (repo root) to your
 #    project before storing any real data:
-#      firebase deploy --only firestore:rules
+#      firebase deploy --only firestore:rules --project <your-project-id>
+#    <your-project-id> is the VITE_FIREBASE_PROJECT_ID value below.
 #    See firestore.rules for the exact rules and docs/getting-started/configuration.md
 #    for more details.
 # 5. Add your domain to Authentication > Settings > Authorized domains

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -40,11 +40,14 @@ BytePad can optionally sync data to Firestore for signed-in users, in addition t
 ### Setup
 
 1. Copy `.env.example` to `.env` and follow the "Firebase Setup Steps" in that file
-2. Before storing any real data, deploy the access rules from `firestore.rules` (repo root) to your Firebase project:
+2. When creating the Firestore database in the Firebase Console, choose **production mode** (locked) as the starting mode, not test mode.
+3. Before storing any real data, deploy the access rules from `firestore.rules` (repo root) to your Firebase project:
    ```bash
-   firebase deploy --only firestore:rules
+   firebase deploy --only firestore:rules --project <your-project-id>
    ```
-   These rules restrict every document to the signed-in user's own `uid` and deny anything not explicitly listed.
+   `<your-project-id>` is the `VITE_FIREBASE_PROJECT_ID` value from your `.env`. The `--project` flag is required because this repo does not commit a `.firebaserc` (doing so in a public repo would hardcode a specific project's ID); alternatively run `firebase use <your-project-id>` once to select it for subsequent commands.
+
+   These rules restrict every document to the signed-in user's own `uid`, to a fixed collection allowlist, and to the literal `data` document id, and deny anything not explicitly listed.
 
 ## AI Configuration
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -2,10 +2,13 @@ rules_version = '2';
 
 // BytePad Firestore access rules.
 //
-// The client (src/services/firestore.ts) only ever reads/writes documents at:
+// The client (src/services/firestore.ts) only ever reads/writes the single,
+// literal document:
 //   users/{uid}/{collection}/data
 // where {collection} is one of the fixed sync collection names used by
 // src/services/cloudSync.ts: notes, tasks, habits, journal, bookmarks.
+// The document id is matched literally (not a wildcard) since the client
+// never writes any other document id under a user's tree.
 //
 // Every path is scoped to the authenticated user's own uid, and any path
 // not explicitly matched below is denied by default.
@@ -14,7 +17,7 @@ rules_version = '2';
 // name to the list below.
 service cloud.firestore {
   match /databases/{database}/documents {
-    match /users/{uid}/{collection}/{docId} {
+    match /users/{uid}/{collection}/data {
       allow read, write: if request.auth != null
         && request.auth.uid == uid
         && collection in ['notes', 'tasks', 'habits', 'journal', 'bookmarks'];


### PR DESCRIPTION
Matches the single document the client actually uses instead of a wildcard, and clarifies the setup steps.