### PR TITLE
chore(firebase): add a project selection template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,9 @@ VITE_FIREBASE_APP_ID=your-app-id
 # 4. Deploy the access rules from firestore.rules (repo root) to your
 #    project before storing any real data:
 #      firebase deploy --only firestore:rules --project <your-project-id>
-#    <your-project-id> is the VITE_FIREBASE_PROJECT_ID value below.
+#    <your-project-id> is the VITE_FIREBASE_PROJECT_ID value above.
+#    Alternatively, copy .firebaserc.example to .firebaserc, set your project
+#    id there, and the --project flag becomes unnecessary.
 #    See firestore.rules for the exact rules and docs/getting-started/configuration.md
 #    for more details.
 # 5. Add your domain to Authentication > Settings > Authorized domains

--- a/.firebaserc.example
+++ b/.firebaserc.example
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "your-project-id"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ dist-electron/
 .env.local
 .env.*.local
 
+# Local Firebase project selection (copy .firebaserc.example)
+.firebaserc
+
 # System files
 Thumbs.db
 ehthumbs.db

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -45,7 +45,15 @@ BytePad can optionally sync data to Firestore for signed-in users, in addition t
    ```bash
    firebase deploy --only firestore:rules --project <your-project-id>
    ```
-   `<your-project-id>` is the `VITE_FIREBASE_PROJECT_ID` value from your `.env`. The `--project` flag is required because this repo does not commit a `.firebaserc` (doing so in a public repo would hardcode a specific project's ID); alternatively run `firebase use <your-project-id>` once to select it for subsequent commands.
+   `<your-project-id>` is the `VITE_FIREBASE_PROJECT_ID` value from your `.env`.
+
+   To avoid passing `--project` every time, copy the template and fill in your own project id:
+
+   ```bash
+   cp .firebaserc.example .firebaserc
+   ```
+
+   `.firebaserc` is gitignored, so your project id stays local. The repo ships only the example: committing a real `.firebaserc` to a public repo would hardcode one specific project's ID for everyone who clones it. Running `firebase use <your-project-id>` once has the same effect.
 
    These rules restrict every document to the signed-in user's own `uid`, to a fixed collection allowlist, and to the literal `data` document id, and deny anything not explicitly listed.
 


### PR DESCRIPTION
Adds a .firebaserc.example template, ignores the real .firebaserc, and corrects a stale reference in the environment template.