### PR TITLE
chore(docker): build the container image from source

### DIFF
--- a/docker/mcp-server/.dockerignore
+++ b/docker/mcp-server/.dockerignore
@@ -1,0 +1,17 @@
+# Build artifacts (produced inside the image by the builder stage)
+dist/
+data/
+
+# Dependencies (installed inside the image)
+node_modules/
+
+# Editor / OS / VCS cruft
+.git/
+.gitignore
+.DS_Store
+*.log
+npm-debug.log*
+
+# Local env files - never bake secrets/keys into the image
+.env
+.env.*

--- a/docker/mcp-server/Dockerfile
+++ b/docker/mcp-server/Dockerfile
@@ -1,4 +1,22 @@
 # bytepad MCP Server - Standalone Docker Image
+
+# ---- Stage 1: builder ----------------------------------------------------
+# Compiles TypeScript -> dist/ inside the image, so the build is
+# reproducible from a clean checkout with no host-side build step.
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+# Install full dependency set (dev deps needed for `tsc`)
+COPY package*.json ./
+RUN npm ci
+
+# Compile
+COPY tsconfig.json ./
+COPY src/ ./src/
+RUN npm run build
+
+# ---- Stage 2: runtime ------------------------------------------------------
 FROM node:20-alpine
 
 LABEL maintainer="Sami Tugal <tugalsami@gmail.com>"
@@ -13,14 +31,14 @@ RUN apk add --no-cache curl
 # Copy package files
 COPY package*.json ./
 
-# Install only production dependencies
+# Install only production dependencies (no devDependencies, no TypeScript)
 RUN npm ci --only=production
 
-# Copy server files
-COPY dist/ ./dist/
-COPY data/ ./data/
+# Copy compiled server output from the builder stage - no sources, no
+# builder node_modules end up in this layer.
+COPY --from=builder /app/dist ./dist/
 
-# Create data directory for persistence
+# Create data directory for persistence (populated at runtime, not build time)
 RUN mkdir -p /app/data
 
 # Environment variables


### PR DESCRIPTION
Restructures the container image as a multi-stage build so it builds from a clean checkout with no host-side prerequisites, and adds a .dockerignore.