### PR TITLE
chore: unify the image-missing guidance and drop a stale doc section

### DIFF
--- a/docs/api/services.md
+++ b/docs/api/services.md
@@ -27,15 +27,6 @@ pushToGist(): Promise<void>
 getSyncStatus(): SyncStatus
 ```
 
-## agentService
-
-FlowBot agent with tool calling.
-
-```typescript
-// Execute agent with tools
-executeAgent(input: string, tools: Tool[]): Promise<AgentResult>
-```
-
 ## notificationService
 
 Desktop notifications and reminders.

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -2,6 +2,7 @@ import { app, BrowserWindow, Tray, Menu, globalShortcut, ipcMain, shell, nativeI
 import path from 'path'
 import Store from 'electron-store'
 import { startMCPServer, stopMCPServer, getServerInfo, getOrCreateApiKey, regenerateApiKey } from './server'
+import { IMAGE_NOT_FOUND_MESSAGE } from './services/dockerService'
 import { setupStoreBridge, setMainWindow } from './server/bridges/storeBridge'
 import {
   isDockerInstalled,
@@ -578,7 +579,7 @@ function setupIPC() {
     if (!hasImage) {
       return {
         success: false,
-        error: 'Docker image not found. Please run: docker-compose build',
+        error: IMAGE_NOT_FOUND_MESSAGE,
         errorCode: 'IMAGE_NOT_FOUND'
       }
     }
@@ -632,7 +633,7 @@ function setupIPC() {
       if (!hasImage) {
         return {
           success: false,
-          error: 'Docker image not built. Run: cd docker/mcp-server && docker-compose build',
+          error: IMAGE_NOT_FOUND_MESSAGE,
           errorCode: 'IMAGE_NOT_FOUND'
         }
       }

--- a/electron/services/dockerService.ts
+++ b/electron/services/dockerService.ts
@@ -19,6 +19,18 @@ const store = new Store();
 const CONTAINER_NAME = 'bytepad-mcp';
 const IMAGE_NAME = 'bytepad/mcp-server';
 const IMAGE_TAG = '0.24.3';
+
+/**
+ * Single definition of the "image missing" guidance shown to users.
+ *
+ * Packaged builds ship only `out/**` (see electron-builder.yml), so they carry
+ * neither docker-compose.yml nor docker/mcp-server/. Any instruction naming
+ * those files is wrong outside a source checkout. Everything that surfaces this
+ * message - main-process IPC handlers and the settings UI - must read it from
+ * here so a copy cannot drift again.
+ */
+export const IMAGE_NOT_FOUND_MESSAGE =
+  `Docker image not found. Build it from the bytepad source with: docker build -t ${IMAGE_NAME}:${IMAGE_TAG} docker/mcp-server`;
 const DEFAULT_PORT = 3847;
 // Loopback only by default; set mcp.docker.host to opt in to wider exposure.
 // Mirrors the embedded server's mcp.host default in electron/server/config.ts.
@@ -339,14 +351,9 @@ export async function startDockerContainer(): Promise<{ success: boolean; error?
 
     // Check if image doesn't exist
     if (errorMessage.includes('Unable to find image') || errorMessage.includes('No such image')) {
-      // Packaged builds don't ship docker-compose.yml (electron-builder only
-      // bundles `out/**/*`), so pointing users at `docker-compose build` is
-      // misleading outside a source checkout. Point at the plain `docker
-      // build` invocation instead, which matches this file's own
-      // (currently unwired) buildDockerImage() and works from source.
       return {
         success: false,
-        error: `Docker image not found. Build it from the bytepad source with: docker build -t ${IMAGE_NAME}:${IMAGE_TAG} docker/mcp-server`,
+        error: IMAGE_NOT_FOUND_MESSAGE,
       };
     }
 

--- a/src/components/settings/MCPSettings.tsx
+++ b/src/components/settings/MCPSettings.tsx
@@ -97,7 +97,9 @@ export function MCPSettings() {
             setInfoMessage('Docker Desktop is installed but not running. Please start Docker Desktop.');
             setError(null);
           } else if (result?.errorCode === 'IMAGE_NOT_FOUND') {
-            setInfoMessage('Docker image not found. Please build it first:\n\ncd docker/mcp-server && docker-compose build');
+            // Show the guidance the main process sent rather than repeating it
+            // here - a second copy is what let this instruction go stale before.
+            setInfoMessage(result?.error || 'Docker image not found. Build it from the bytepad source first.');
             setError(null);
           } else {
             setError(result?.error || 'Failed to start Docker container');


### PR DESCRIPTION
Collapses three copies of a build instruction into one shared definition, has the settings panel surface the message it already receives, and removes documentation for a module that was deleted.