### PR TITLE
fix(server): normalise repeated query parameters

### DIFF
--- a/docker/mcp-server/src/routes.ts
+++ b/docker/mcp-server/src/routes.ts
@@ -3,6 +3,7 @@
  */
 
 import { Router, Request, Response } from 'express';
+import { singleQueryString } from './utils/queryParams.js';
 
 interface StoreBridge {
   getAll(storeName: string): Promise<unknown[]>;
@@ -94,7 +95,7 @@ export function createRoutes(storeBridge: StoreBridge): Router {
     // GET search
     router.get(`/${storeName}/search`, async (req: Request, res: Response) => {
       try {
-        const query = req.query.q as string || '';
+        const query = singleQueryString(req.query.q) ?? '';
         const items = await storeBridge.search(storeName, query);
         res.json({ success: true, data: items });
       } catch (err) {

--- a/docker/mcp-server/src/server.ts
+++ b/docker/mcp-server/src/server.ts
@@ -21,6 +21,7 @@ import { fileStoreBridge, initializeStore, onStoreChange } from './fileStoreBrid
 import { createRoutes } from './routes.js';
 import { logger } from './logger.js';
 import { hasApiKey, validateApiKey } from './apiKey.js';
+import { singleQueryString } from './utils/queryParams.js';
 
 const PORT = parseInt(process.env.MCP_PORT || '3847', 10);
 const HOST = process.env.MCP_HOST || '0.0.0.0';
@@ -391,7 +392,7 @@ async function startServer(): Promise<void> {
 
   // MCP messages endpoint - receives client JSON-RPC requests
   app.post('/messages', async (req: Request, res: Response) => {
-    const sessionId = req.query.sessionId as string;
+    const sessionId = singleQueryString(req.query.sessionId);
 
     if (!sessionId) {
       res.status(400).json({ error: 'Missing sessionId parameter' });

--- a/docker/mcp-server/src/utils/queryParams.ts
+++ b/docker/mcp-server/src/utils/queryParams.ts
@@ -1,0 +1,16 @@
+/**
+ * Express types `req.query` values as `string | string[] | ParsedQs | ParsedQs[] | undefined`
+ * because repeated query params (e.g. `?q=a&q=b`) are legal and produce an array at runtime.
+ * Casting a query value straight to `string` with `as` overrides that union instead of
+ * checking it, and survives a strict `tsc` build even though the value can be an array.
+ *
+ * Use this helper anywhere a query param is expected to be exactly one string. A duplicated
+ * param (array) or a nested param (`?q[x]=y`, parsed as an object) is deliberately treated as
+ * invalid rather than silently resolved to "the first one" - the caller sent something the
+ * endpoint doesn't support, and picking a value on their behalf would hide that. Callers should
+ * respond with a 400 when this returns `undefined` instead of passing the raw value on and
+ * crashing downstream (e.g. `['a','b'].toLowerCase is not a function`).
+ */
+export function singleQueryString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}

--- a/electron/server/index.ts
+++ b/electron/server/index.ts
@@ -13,6 +13,7 @@ import { getOrCreateApiKey, validateApiKey } from './utils/apiKey';
 import { logger, setLogLevel } from './utils/logger';
 import apiRoutes from './routes';
 import { onStoreChange } from './bridges/storeBridge';
+import { singleQueryString } from './utils/queryParams';
 import { createMCPServer } from './mcp';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
@@ -234,7 +235,7 @@ export async function startMCPServer(config?: Partial<ServerConfig>): Promise<vo
 
   // MCP messages endpoint - receives client JSON-RPC requests
   app.post('/messages', async (req: Request, res: Response) => {
-    const sessionId = req.query.sessionId as string;
+    const sessionId = singleQueryString(req.query.sessionId);
 
     if (!sessionId) {
       logger.warn('MCP messages: Missing sessionId parameter');

--- a/electron/server/routes/bookmarks.ts
+++ b/electron/server/routes/bookmarks.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from 'express';
 import { z } from 'zod';
 import { storeBridge } from '../bridges/storeBridge';
 import { logger } from '../utils/logger';
+import { singleQueryString } from '../utils/queryParams';
 
 const router = Router();
 
@@ -90,7 +91,7 @@ router.get('/', async (req: Request, res: Response) => {
 // GET /api/bookmarks/search - Search bookmarks
 router.get('/search', async (req: Request, res: Response) => {
   try {
-    const query = req.query.q as string;
+    const query = singleQueryString(req.query.q);
     if (!query) {
       return res.status(400).json({
         success: false,

--- a/electron/server/routes/notes.ts
+++ b/electron/server/routes/notes.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from 'express';
 import { z } from 'zod';
 import { storeBridge } from '../bridges/storeBridge';
 import { logger } from '../utils/logger';
+import { singleQueryString } from '../utils/queryParams';
 
 const router = Router();
 
@@ -58,7 +59,7 @@ router.get('/', async (_req: Request, res: Response) => {
 // GET /api/notes/search - Search notes
 router.get('/search', async (req: Request, res: Response) => {
   try {
-    const query = req.query.q as string;
+    const query = singleQueryString(req.query.q);
     if (!query) {
       return res.status(400).json({
         success: false,

--- a/electron/server/routes/tasks.ts
+++ b/electron/server/routes/tasks.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from 'express';
 import { z } from 'zod';
 import { storeBridge } from '../bridges/storeBridge';
 import { logger } from '../utils/logger';
+import { singleQueryString } from '../utils/queryParams';
 
 const router = Router();
 
@@ -110,7 +111,7 @@ router.get('/', async (req: Request, res: Response) => {
 // GET /api/tasks/search - Search tasks
 router.get('/search', async (req: Request, res: Response) => {
   try {
-    const query = req.query.q as string;
+    const query = singleQueryString(req.query.q);
     if (!query) {
       return res.status(400).json({
         success: false,

--- a/electron/server/utils/queryParams.ts
+++ b/electron/server/utils/queryParams.ts
@@ -1,0 +1,16 @@
+/**
+ * Express types `req.query` values as `string | string[] | ParsedQs | ParsedQs[] | undefined`
+ * because repeated query params (e.g. `?q=a&q=b`) are legal and produce an array at runtime.
+ * Casting a query value straight to `string` with `as` overrides that union instead of
+ * checking it, and survives a strict `tsc` build even though the value can be an array.
+ *
+ * Use this helper anywhere a query param is expected to be exactly one string. A duplicated
+ * param (array) or a nested param (`?q[x]=y`, parsed as an object) is deliberately treated as
+ * invalid rather than silently resolved to "the first one" - the caller sent something the
+ * endpoint doesn't support, and picking a value on their behalf would hide that. Callers should
+ * respond with a 400 when this returns `undefined` instead of passing the raw value on and
+ * crashing downstream (e.g. `['a','b'].toLowerCase is not a function`).
+ */
+export function singleQueryString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}


### PR DESCRIPTION
Replaces assertions on query parameters with a checked helper across both servers, so a repeated parameter is rejected with a 400 instead of reaching code that expects a single string.