### PR TITLE
chore: route renderer logging through a shared utility

### DIFF
--- a/src/components/analysis/AnalysisModule.tsx
+++ b/src/components/analysis/AnalysisModule.tsx
@@ -5,6 +5,7 @@ import { useJournalStore } from '../../stores/journalStore'
 import { calculateWeeklyStats, getWeekRange, generateAIInsights, type WeeklyStats } from '../../services/analysisService'
 import { generateReportWithAgent } from '../../services/reportAgentService'
 import { useTranslation } from '../../i18n'
+import { logger } from '../../utils/logger'
 import { ProductivityReport } from './ProductivityReport'
 
 const DAYS_SHORT = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
@@ -91,7 +92,7 @@ export function AnalysisModule() {
       const result = await generateAIInsights(stats)
       setAiInsights(result)
     } catch (error) {
-      console.error('AI Insights error:', error)
+      logger.error('AI Insights error:', error)
     } finally {
       setIsLoadingAI(false)
     }
@@ -105,7 +106,7 @@ export function AnalysisModule() {
       setMdReport({ markdown: result.markdown, generatedAt: result.generatedAt })
       setShowMdPreview(true)
     } catch (error) {
-      console.error('MD Report error:', error)
+      logger.error('MD Report error:', error)
     } finally {
       setIsLoadingMdReport(false)
     }

--- a/src/components/analysis/ProductivityReport.tsx
+++ b/src/components/analysis/ProductivityReport.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useTranslation } from '../../i18n'
 import { useReportStore } from '../../stores/reportStore'
 import { generateProductivityReport } from '../../services/productivityReportService'
+import { logger } from '../../utils/logger'
 import { ReportSummary } from './ReportSummary'
 import { StrengthsWeaknesses } from './StrengthsWeaknesses'
 import { AchievementsMissed } from './AchievementsMissed'
@@ -30,7 +31,7 @@ export function ProductivityReport({ onClose }: ProductivityReportProps) {
       await generateProductivityReport(period)
       setSelectedReport(null)
     } catch (error) {
-      console.error('Report generation failed:', error)
+      logger.error('Report generation failed:', error)
     }
   }
 

--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -5,6 +5,7 @@ import { useHabitStore } from '../../stores/habitStore'
 import { useJournalStore } from '../../stores/journalStore'
 import { sendMessage } from '../../services/aiService'
 import { useTranslation } from '../../i18n'
+import { logger } from '../../utils/logger'
 import type { ChatContext } from '../../types'
 
 // Destructive tools that require confirmation (for future use)
@@ -101,7 +102,7 @@ export function ChatWindow() {
       // Use the agent's natural language response only - never show raw tool results
       addMessage({ role: 'assistant', content: response.content })
     } catch (err) {
-      console.error('[FlowBot Error]', err)
+      logger.error('[FlowBot Error]', err)
       const errorMessage = err instanceof Error ? err.message : 'Bir hata oluştu'
 
       if (errorMessage.includes('API key') || errorMessage.includes('apiKey')) {

--- a/src/components/common/ErrorBoundary.tsx
+++ b/src/components/common/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { Component, ErrorInfo, ReactNode } from 'react'
+import { logger } from '../../utils/logger'
 
 interface Props {
   children: ReactNode
@@ -21,7 +22,7 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    console.error('ErrorBoundary caught an error:', error, errorInfo)
+    logger.error('ErrorBoundary caught an error:', error, errorInfo)
   }
 
   handleReload = () => {

--- a/src/components/common/SettingsPanel.tsx
+++ b/src/components/common/SettingsPanel.tsx
@@ -3,6 +3,7 @@ import { exportAllData, downloadAsJson, importData, readFileAsJson, clearAllData
 import { useSettingsStore, LLM_MODELS, PROVIDER_INFO, LLMProvider, FONT_SIZES, FontSize, FONT_FAMILIES, FontFamily, ApiKeyType, GistSyncPreferences } from '../../stores/settingsStore'
 import { useI18nStore, useTranslation, LANGUAGES, Language } from '../../i18n'
 import { isElectron } from '../../utils/storage'
+import { logger } from '../../utils/logger'
 import { useThemeStore, Theme } from '../../stores/themeStore'
 import { useNotificationStore } from '../../stores/notificationStore'
 import { useAuthStore } from '../../stores/authStore'
@@ -1009,16 +1010,13 @@ function DataTab({
     const [isSavingNotes, setIsSavingNotes] = useState(false)
 
     const handleSelectFolder = async () => {
-        console.log('Select Folder clicked')
-
         // Check if File System Access API is supported
         if (!('showDirectoryPicker' in window)) {
             setLocalNotesStatus('Error: Your browser does not support folder selection. Please use Chrome, Edge, or Opera.')
-            console.error('showDirectoryPicker not supported')
+            logger.warn('showDirectoryPicker not supported')
             return
         }
 
-        console.log('showDirectoryPicker is supported, opening dialog...')
         setLocalNotesStatus('Opening folder picker...')
 
         try {
@@ -1027,8 +1025,6 @@ function DataTab({
                 mode: 'readwrite',
             })
 
-            console.log('Folder selected:', dirHandle)
-
             if (dirHandle) {
                 setLocalNotesDirHandle(dirHandle)
                 setLocalNotesPath(dirHandle.name)
@@ -1036,7 +1032,7 @@ function DataTab({
                 setLocalNotesStatus(`✓ Folder selected: ${dirHandle.name}`)
             }
         } catch (error) {
-            console.error('Folder selection error:', error)
+            logger.error('Folder selection error:', error)
             if ((error as Error).name === 'AbortError') {
                 // User cancelled
                 setLocalNotesStatus('Folder selection cancelled')
@@ -1081,7 +1077,7 @@ function DataTab({
             const result = await downloadAllDataAsZip()
             setLocalNotesStatus(`✓ Downloaded ZIP with ${result.notes} notes, ${result.tasks} tasks, ${result.habits} habits, ${result.journal} journal entries`)
         } catch (error) {
-            console.error('ZIP download error:', error)
+            logger.error('ZIP download error:', error)
             setLocalNotesStatus(`Error: ${error instanceof Error ? error.message : 'Failed to create ZIP'}`)
         }
     }

--- a/src/components/graph/GraphModule.tsx
+++ b/src/components/graph/GraphModule.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from '../../i18n'
 import { GraphVisualization } from './GraphVisualization'
 import { GraphControls } from './GraphControls'
 import { buildGraphData, collectAllTags } from '../../utils/graphUtils'
+import { logger } from '../../utils/logger'
 import type { GraphEntityType } from '../../types'
 
 const GRAPH_FILTERS_KEY = 'bytepad-graph-filters'
@@ -31,7 +32,7 @@ function loadFilters() {
       return { ...defaultFilters, ...JSON.parse(saved) }
     }
   } catch (e) {
-    console.error('Failed to load graph filters:', e)
+    logger.error('Failed to load graph filters:', e)
   }
   return defaultFilters
 }

--- a/src/components/notes/NoteEditor.tsx
+++ b/src/components/notes/NoteEditor.tsx
@@ -13,6 +13,7 @@ import { NoteSearch } from './NoteSearch'
 import { ConfirmModal } from '../common'
 import { useTranslation } from '../../i18n'
 import { parseTags } from '../../utils/storage'
+import { logger } from '../../utils/logger'
 import type { Note } from '../../types'
 
 function ImageRenderer({ src, alt }: { src?: string; alt?: string }) {
@@ -202,7 +203,7 @@ export function NoteEditor() {
       await autoSaveNoteLocally(updatedNote)
     } catch (error) {
       // Silently fail - local save is optional
-      console.debug('Local note save skipped:', error)
+      logger.debug('Local note save skipped:', error)
     }
   }, [activeNoteId, title, content, tags, updateNote, tabs, updateTabTitle, activeNote])
 

--- a/src/components/tasks/TaskKanban.tsx
+++ b/src/components/tasks/TaskKanban.tsx
@@ -327,8 +327,6 @@ export function TaskKanban({
 
     const currentStatus = getTaskStatus(task)
     if (currentStatus === targetStatus) return
-    
-    console.log('Kanban: Moving task', taskId, 'from', currentStatus, 'to', targetStatus)
 
     // Update task based on new status
     if (targetStatus === 'done') {

--- a/src/hooks/useServiceWorker.ts
+++ b/src/hooks/useServiceWorker.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { logger } from '../utils/logger';
 
 interface ServiceWorkerState {
   isSupported: boolean;
@@ -45,7 +46,7 @@ export function useServiceWorker(): UseServiceWorkerReturn {
     const registerSW = async () => {
       try {
         const registration = await navigator.serviceWorker.register('/sw.js');
-        console.log('[App] SW registered:', registration.scope);
+        logger.info('[App] SW registered:', registration.scope);
 
         setState((s) => ({
           ...s,
@@ -67,12 +68,12 @@ export function useServiceWorker(): UseServiceWorkerReturn {
           const newWorker = registration.installing;
           if (!newWorker) return;
 
-          console.log('[App] New SW installing...');
+          logger.info('[App] New SW installing...');
 
           newWorker.addEventListener('statechange', () => {
             if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
               // New SW installed, waiting to activate
-              console.log('[App] New SW installed, update available');
+              logger.info('[App] New SW installed, update available');
               setState((s) => ({
                 ...s,
                 isUpdateAvailable: true,
@@ -84,11 +85,11 @@ export function useServiceWorker(): UseServiceWorkerReturn {
 
         // Handle controller change (after skipWaiting)
         navigator.serviceWorker.addEventListener('controllerchange', () => {
-          console.log('[App] Controller changed, reloading...');
+          logger.info('[App] Controller changed, reloading...');
           window.location.reload();
         });
       } catch (error) {
-        console.error('[App] SW registration failed:', error);
+        logger.error('[App] SW registration failed:', error);
       }
     };
 
@@ -100,7 +101,7 @@ export function useServiceWorker(): UseServiceWorkerReturn {
     const { waitingWorker } = state;
     if (!waitingWorker) return;
 
-    console.log('[App] Sending SKIP_WAITING to SW');
+    logger.info('[App] Sending SKIP_WAITING to SW');
     waitingWorker.postMessage({ type: 'SKIP_WAITING' });
   }, [state.waitingWorker]);
 
@@ -111,9 +112,9 @@ export function useServiceWorker(): UseServiceWorkerReturn {
 
     try {
       await registration.update();
-      console.log('[App] Checked for updates');
+      logger.debug('[App] Checked for updates');
     } catch (error) {
-      console.error('[App] Update check failed:', error);
+      logger.error('[App] Update check failed:', error);
     }
   }, [state.registration]);
 

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -11,6 +11,7 @@ import { useNoteStore } from '../stores/noteStore'
 import { useJournalStore } from '../stores/journalStore'
 import { useBookmarkStore } from '../stores/bookmarkStore'
 import type { ChatMessage, ChatContext } from '../types'
+import { logger } from '../utils/logger'
 
 // Build dynamic system prompt with current datetime
 function buildSystemPrompt(): string {
@@ -103,7 +104,7 @@ async function searchWithTavily(query: string, maxResults: number = 5): Promise<
 
     if (!response.ok) {
       const errorText = await response.text()
-      console.error('[Tavily] Error:', response.status, errorText)
+      logger.error('[Tavily] Error:', response.status, errorText)
       return `Search failed: ${response.status}`
     }
 
@@ -124,7 +125,7 @@ async function searchWithTavily(query: string, maxResults: number = 5): Promise<
 
     return result || 'No results found.'
   } catch (error) {
-    console.error('[Tavily] Error:', error)
+    logger.error('[Tavily] Error:', error)
     return `Search error: ${error instanceof Error ? error.message : 'Unknown error'}`
   }
 }
@@ -1049,7 +1050,7 @@ function getLLM() {
   const { llmProvider, llmModel, apiKeys } = useSettingsStore.getState()
   const apiKey = apiKeys[llmProvider]
 
-  console.log('[AI Service] Provider:', llmProvider, 'Model:', llmModel, 'API Key exists:', !!apiKey, 'Key length:', apiKey?.length)
+  logger.debug('[AI Service] Provider:', llmProvider, 'Model:', llmModel, 'API Key exists:', !!apiKey, 'Key length:', apiKey?.length)
 
   if (!apiKey) {
     throw new Error(`API key for ${llmProvider} is not configured. Please set it in Settings → AI.`)
@@ -1133,12 +1134,12 @@ export async function sendMessage(
     // Agent loop - continues until agent decides to respond (no more tool calls)
     while (iterations < MAX_ITERATIONS) {
       iterations++
-      console.log(`[Agent] Iteration ${iterations}/${MAX_ITERATIONS}, sending to LLM...`)
+      logger.debug(`[Agent] Iteration ${iterations}/${MAX_ITERATIONS}, sending to LLM...`)
 
       const response = await llmWithTools.invoke(messages)
 
       // Debug: log full response
-      console.log('[Agent] Response:', {
+      logger.debug('[Agent] Response:', {
         hasContent: !!response.content,
         contentLength: typeof response.content === 'string' ? response.content.length : 0,
         contentPreview: typeof response.content === 'string' ? response.content.substring(0, 200) : response.content,
@@ -1148,11 +1149,11 @@ export async function sendMessage(
       // If no tool calls, agent is done - return final response
       if (!response.tool_calls?.length) {
         const content = typeof response.content === 'string' ? response.content : ''
-        console.log('[Agent] No tool calls, returning final response:', content.substring(0, 100))
+        logger.debug('[Agent] No tool calls, returning final response:', content.substring(0, 100))
 
         // If content is empty but we have tool results, generate friendly summary
         if (!content && toolResults.length > 0) {
-          console.warn('[Agent] Empty response after tool execution - generating summary')
+          logger.warn('[Agent] Empty response after tool execution - generating summary')
           return {
             content: generateFriendlySummary(toolResults),
             toolResults
@@ -1165,7 +1166,7 @@ export async function sendMessage(
         }
       }
 
-      console.log(`[Agent] Tool calls: ${response.tool_calls.map(tc => tc.name).join(', ')}`)
+      logger.debug(`[Agent] Tool calls: ${response.tool_calls.map(tc => tc.name).join(', ')}`)
 
       // Add assistant message with tool calls to history
       messages.push(response)
@@ -1179,10 +1180,10 @@ export async function sendMessage(
           try {
             result = await executor(toolCall.args as Record<string, unknown>)
             toolResults.push(result)
-            console.log(`[Agent] Tool ${toolCall.name} executed:`, result.substring(0, 100))
+            logger.debug(`[Agent] Tool ${toolCall.name} executed:`, result.substring(0, 100))
           } catch (toolError) {
             result = `Error executing ${toolCall.name}: ${toolError}`
-            console.error(`[Agent] Tool error:`, toolError)
+            logger.error(`[Agent] Tool error:`, toolError)
           }
         } else {
           result = `Unknown tool: ${toolCall.name}`
@@ -1204,13 +1205,13 @@ export async function sendMessage(
     }
 
     // Max iterations reached - generate friendly summary instead of error
-    console.warn('[Agent] Max iterations reached, generating summary')
+    logger.warn('[Agent] Max iterations reached, generating summary')
     return {
       content: generateFriendlySummary(toolResults),
       toolResults
     }
   } catch (error) {
-    console.error('[Agent Error]', error)
+    logger.error('[Agent Error]', error)
     throw error
   }
 }

--- a/src/services/analysisService.ts
+++ b/src/services/analysisService.ts
@@ -1,5 +1,6 @@
 import type { Habit, Task, JournalEntry } from '../types'
 import { useSettingsStore, PROVIDER_INFO } from '../stores/settingsStore'
+import { logger } from '../utils/logger'
 
 export interface WeeklyStats {
   weekStart: string
@@ -320,7 +321,7 @@ export async function generateAIInsights(stats: WeeklyStats): Promise<{
 
     return parseAIInsightsResponse(response, stats)
   } catch (error) {
-    console.error('AI Insights error:', error)
+    logger.error('AI Insights error:', error)
     return {
       insights: stats.insights,
       recommendations: stats.recommendations,
@@ -487,7 +488,7 @@ function parseAIInsightsResponse(
       }
     }
   } catch (e) {
-    console.error('Failed to parse AI response:', e)
+    logger.error('Failed to parse AI response:', e)
   }
 
   return {
@@ -531,7 +532,7 @@ export async function generateAIMarkdownReport(stats: WeeklyStats): Promise<AIMa
       generatedAt: new Date().toISOString(),
     }
   } catch (error) {
-    console.error('AI Markdown Report error:', error)
+    logger.error('AI Markdown Report error:', error)
     return {
       markdown: generateFallbackMarkdownReport(stats),
       generatedAt: new Date().toISOString(),

--- a/src/services/cloudSync.ts
+++ b/src/services/cloudSync.ts
@@ -11,6 +11,7 @@ import { useHabitStore } from '../stores/habitStore'
 import { useJournalStore } from '../stores/journalStore'
 import { useBookmarkStore } from '../stores/bookmarkStore'
 import type { Note, Task, Habit, JournalEntry, Bookmark } from '../types'
+import { logger } from '../utils/logger'
 
 interface HabitSyncData {
   habits: Habit[]
@@ -75,11 +76,11 @@ const syncBookmarksToCloud = debounce(async () => {
 // Initialize cloud sync - call this after user logs in
 export async function initializeCloudSync(): Promise<void> {
   if (!isFirestoreConfigured() || !getCurrentUser()) {
-    console.log('Cloud sync not available: Firebase not configured or user not logged in')
+    logger.info('Cloud sync not available: Firebase not configured or user not logged in')
     return
   }
 
-  console.log('Initializing cloud sync...')
+  logger.info('Initializing cloud sync...')
 
   // Load initial data from cloud
   await loadAllDataFromCloud()
@@ -90,7 +91,7 @@ export async function initializeCloudSync(): Promise<void> {
   // Subscribe to local store changes
   setupLocalListeners()
 
-  console.log('Cloud sync initialized')
+  logger.info('Cloud sync initialized')
 }
 
 // Load all data from cloud
@@ -228,7 +229,7 @@ function setupLocalListeners(): void {
 export function stopCloudSync(): void {
   unsubscribers.forEach(unsub => unsub())
   unsubscribers.length = 0
-  console.log('Cloud sync stopped')
+  logger.info('Cloud sync stopped')
 }
 
 // Force sync all data to cloud
@@ -249,5 +250,5 @@ export async function forceSyncToCloud(): Promise<void> {
     saveUserData('bookmarks', bookmarks),
   ])
 
-  console.log('Force sync to cloud completed')
+  logger.info('Force sync to cloud completed')
 }

--- a/src/services/firebase.ts
+++ b/src/services/firebase.ts
@@ -1,5 +1,6 @@
 import { initializeApp, FirebaseApp } from 'firebase/app'
 import { getAuth, GoogleAuthProvider, signInWithPopup, signOut, onAuthStateChanged, User, Auth } from 'firebase/auth'
+import { logger } from '../utils/logger'
 
 // Firebase configuration - User needs to add their own config
 const firebaseConfig = {
@@ -32,15 +33,15 @@ const googleProvider = new GoogleAuthProvider()
 
 export const signInWithGoogle = async (): Promise<User | null> => {
   if (!auth) {
-    console.warn('Firebase not configured. Please add Firebase config to .env file.')
+    logger.warn('Firebase not configured. Please add Firebase config to .env file.')
     return null
   }
-  
+
   try {
     const result = await signInWithPopup(auth, googleProvider)
     return result.user
   } catch (error) {
-    console.error('Google sign-in error:', error)
+    logger.error('Google sign-in error:', error)
     return null
   }
 }
@@ -51,7 +52,7 @@ export const signOutUser = async (): Promise<void> => {
   try {
     await signOut(auth)
   } catch (error) {
-    console.error('Sign-out error:', error)
+    logger.error('Sign-out error:', error)
   }
 }
 

--- a/src/services/firestore.ts
+++ b/src/services/firestore.ts
@@ -9,6 +9,7 @@ import {
 } from 'firebase/firestore'
 import { onAuthStateChanged, User } from 'firebase/auth'
 import { app, auth, isFirebaseConfigured } from './firebase'
+import { logger } from '../utils/logger'
 
 // Firebase app/auth are initialized once in src/services/firebase.ts;
 // this module only derives Firestore from that shared app instance.
@@ -42,7 +43,7 @@ export async function saveUserData<T>(
       userId: currentUser.uid
     })
   } catch (error) {
-    console.error(`Error saving ${collectionName}:`, error)
+    logger.error(`Error saving ${collectionName}:`, error)
   }
 }
 
@@ -60,7 +61,7 @@ export async function loadUserData<T>(
     }
     return null
   } catch (error) {
-    console.error(`Error loading ${collectionName}:`, error)
+    logger.error(`Error loading ${collectionName}:`, error)
     return null
   }
 }
@@ -81,13 +82,13 @@ export function subscribeToUserData<T>(
         callback(null)
       }
     }, (error) => {
-      console.error(`Error subscribing to ${collectionName}:`, error)
+      logger.error(`Error subscribing to ${collectionName}:`, error)
     })
     
     unsubscribers.push(unsubscribe)
     return unsubscribe
   } catch (error) {
-    console.error(`Error setting up subscription for ${collectionName}:`, error)
+    logger.error(`Error setting up subscription for ${collectionName}:`, error)
     return null
   }
 }

--- a/src/services/gistSyncService.ts
+++ b/src/services/gistSyncService.ts
@@ -12,6 +12,7 @@ import { useDailyNotesStore } from '../stores/dailyNotesStore'
 import { useFocusStore } from '../stores/focusStore'
 import { useGamificationStore, deriveLevelAndXP } from '../stores/gamificationStore'
 import { useIdeaStore } from '../stores/ideaStore'
+import { logger } from '../utils/logger'
 
 const GIST_FILENAME = 'bytepad-data.json'
 
@@ -393,7 +394,7 @@ function parseSyncData(raw: unknown): SyncData {
         if (value === undefined || value === null) return undefined
         const parsed = syncCollectionSchema.safeParse(value)
         if (!parsed.success) {
-            console.warn(`[GistSync] Dropping corrupt "${key}" collection from remote data:`, parsed.error.issues)
+            logger.warn(`[GistSync] Dropping corrupt "${key}" collection from remote data:`, parsed.error.issues)
             return undefined
         }
         return parsed.data
@@ -405,7 +406,7 @@ function parseSyncData(raw: unknown): SyncData {
         if (parsedGamification.success) {
             gamification = parsedGamification.data
         } else {
-            console.warn('[GistSync] Dropping corrupt gamification data from remote (missing/invalid totalXP):', parsedGamification.error.issues)
+            logger.warn('[GistSync] Dropping corrupt gamification data from remote (missing/invalid totalXP):', parsedGamification.error.issues)
         }
     }
 
@@ -415,7 +416,7 @@ function parseSyncData(raw: unknown): SyncData {
         if (parsedFocusStats.success) {
             focusStats = parsedFocusStats.data
         } else {
-            console.warn('[GistSync] Dropping corrupt focusStats data from remote:', parsedFocusStats.error.issues)
+            logger.warn('[GistSync] Dropping corrupt focusStats data from remote:', parsedFocusStats.error.issues)
         }
     }
 
@@ -575,12 +576,12 @@ export async function writeToGist(token: string, gistId: string, skipValidation:
         const validation = validateDataBeforePush(data, remoteData)
         
         if (!validation.valid) {
-            console.warn('[GistSync] Push blocked due to potential data loss:', validation.warnings)
+            logger.warn('[GistSync] Push blocked due to potential data loss:', validation.warnings)
             throw new Error(`Push blocked: ${validation.warnings.join('; ')}`)
         }
         
         if (validation.warnings.length > 0) {
-            console.warn('[GistSync] Push warnings:', validation.warnings)
+            logger.warn('[GistSync] Push warnings:', validation.warnings)
         }
     }
 
@@ -641,7 +642,7 @@ export async function syncWithGist(): Promise<{ success: boolean; message: strin
             // SAFETY: If remote has more data than local, always pull first
             // This prevents pushing incomplete/corrupted local data
             if (remoteItemCount > localItemCount) {
-                console.log(`[GistSync] Remote has more data (${remoteItemCount} vs ${localItemCount}), pulling...`)
+                logger.info(`[GistSync] Remote has more data (${remoteItemCount} vs ${localItemCount}), pulling...`)
                 applyData(remoteData)
                 setGistSync({
                     lastSyncAt: new Date().toISOString(),
@@ -770,7 +771,7 @@ export async function pullOnStartup(): Promise<{ success: boolean; message: stri
         return { success: false, message: 'Gist sync not configured' }
     }
 
-    console.log('[GistSync] Pulling data on startup...')
+    logger.info('[GistSync] Pulling data on startup...')
     setGistSync({ lastSyncStatus: 'pending' })
 
     try {
@@ -783,14 +784,14 @@ export async function pullOnStartup(): Promise<{ success: boolean; message: stri
                 lastSyncStatus: 'success',
                 lastSyncError: null,
             })
-            console.log('[GistSync] Startup pull completed successfully')
+            logger.info('[GistSync] Startup pull completed successfully')
             return { success: true, message: 'Pulled data from Gist' }
         }
         
         return { success: true, message: 'No remote data found' }
     } catch (error) {
         const errorMessage = error instanceof Error ? error.message : 'Unknown error'
-        console.error('[GistSync] Startup pull failed:', error)
+        logger.error('[GistSync] Startup pull failed:', error)
         setGistSync({
             lastSyncStatus: 'error',
             lastSyncError: errorMessage,
@@ -808,7 +809,7 @@ export async function pushOnClose(): Promise<{ success: boolean; message: string
         return { success: false, message: 'Gist sync not configured' }
     }
 
-    console.log('[GistSync] Pushing data on close...')
+    logger.info('[GistSync] Pushing data on close...')
     setGistSync({ lastSyncStatus: 'pending' })
 
     try {
@@ -820,11 +821,11 @@ export async function pushOnClose(): Promise<{ success: boolean; message: string
             lastSyncStatus: 'success',
             lastSyncError: null,
         })
-        console.log('[GistSync] Close push completed successfully')
+        logger.info('[GistSync] Close push completed successfully')
         return { success: true, message: 'Pushed data to Gist' }
     } catch (error) {
         const errorMessage = error instanceof Error ? error.message : 'Unknown error'
-        console.error('[GistSync] Close push failed:', error)
+        logger.error('[GistSync] Close push failed:', error)
         setGistSync({
             lastSyncStatus: 'error',
             lastSyncError: errorMessage,
@@ -843,7 +844,7 @@ export function initializeSync(): void {
     }
 
     // Wait for stores to hydrate, then pull
-    console.log('[GistSync] Waiting for stores to hydrate...')
+    logger.info('[GistSync] Waiting for stores to hydrate...')
     setTimeout(() => {
         pullOnStartup()
     }, INITIAL_SYNC_DELAY_MS)

--- a/src/services/ipcStoreService.ts
+++ b/src/services/ipcStoreService.ts
@@ -13,6 +13,7 @@ import { useDailyNotesStore } from '../stores/dailyNotesStore';
 import { useFocusStore } from '../stores/focusStore';
 import { useGamificationStore } from '../stores/gamificationStore';
 import { useSettingsStore } from '../stores/settingsStore';
+import { logger } from '../utils/logger';
 
 type StoreName =
   | 'notes'
@@ -360,17 +361,17 @@ declare global {
 // Initialize IPC listeners
 export function initializeIpcStoreService() {
   if (window.__IPC_STORE_INITIALIZED__) {
-    console.log('[IPC Store] Already initialized, skipping');
+    logger.debug('[IPC Store] Already initialized, skipping');
     return;
   }
 
   if (!window.electronAPI) {
-    console.log('[IPC Store] Not in Electron environment');
+    logger.debug('[IPC Store] Not in Electron environment');
     return;
   }
 
   window.__IPC_STORE_INITIALIZED__ = true;
-  console.log('[IPC Store] Initializing...');
+  logger.debug('[IPC Store] Initializing...');
 
   const { storeBridge } = window.electronAPI as { storeBridge?: {
     onStoreRequest: (handler: (channel: string, requestId: string, ...args: unknown[]) => void) => void;
@@ -379,11 +380,11 @@ export function initializeIpcStoreService() {
   }};
 
   if (!storeBridge) {
-    console.log('[IPC Store] Store bridge not available in preload');
+    logger.debug('[IPC Store] Store bridge not available in preload');
     return;
   }
 
-  console.log('[IPC Store] Initializing store bridge via preload...');
+  logger.debug('[IPC Store] Initializing store bridge via preload...');
 
   // Handle all store requests from main process
   storeBridge.onStoreRequest((channel, requestId, ...args) => {
@@ -445,5 +446,5 @@ export function initializeIpcStoreService() {
     }
   });
 
-  console.log('[IPC Store] Store bridge initialized');
+  logger.debug('[IPC Store] Store bridge initialized');
 }

--- a/src/services/localNotesService.ts
+++ b/src/services/localNotesService.ts
@@ -6,6 +6,7 @@ import { useTaskStore } from '../stores/taskStore'
 import { useHabitStore } from '../stores/habitStore'
 import { useJournalStore } from '../stores/journalStore'
 import type { Note, Task, Habit, JournalEntry } from '../types'
+import { logger } from '../utils/logger'
 
 // Check if File System Access API is supported
 export const isFileSystemAccessSupported = (): boolean => {
@@ -24,7 +25,7 @@ const sanitizeFilename = (name: string): string => {
 // Request directory access from user
 export const selectNotesDirectory = async (): Promise<{ handle: FileSystemDirectoryHandle; path: string } | null> => {
   if (!isFileSystemAccessSupported()) {
-    console.warn('File System Access API is not supported in this browser')
+    logger.warn('File System Access API is not supported in this browser')
     return null
   }
 
@@ -44,7 +45,7 @@ export const selectNotesDirectory = async (): Promise<{ handle: FileSystemDirect
       // User cancelled the picker
       return null
     }
-    console.error('Error selecting directory:', error)
+    logger.error('Error selecting directory:', error)
     throw error
   }
 }
@@ -69,7 +70,7 @@ export const saveNoteToFile = async (note: Note, dirHandle: FileSystemDirectoryH
     
     return true
   } catch (error) {
-    console.error('Error saving note to file:', error)
+    logger.error('Error saving note to file:', error)
     return false
   }
 }
@@ -135,7 +136,7 @@ export const autoSaveNoteLocally = async (note: Note): Promise<void> => {
   try {
     await saveNoteToFile(note, localNotesDirHandle)
   } catch (error) {
-    console.error('Auto-save to local file failed:', error)
+    logger.error('Auto-save to local file failed:', error)
   }
 }
 
@@ -153,7 +154,7 @@ export const deleteNoteFile = async (noteTitle: string): Promise<boolean> => {
     return true
   } catch (error) {
     // File might not exist, which is fine
-    console.warn('Could not delete note file:', error)
+    logger.warn('Could not delete note file:', error)
     return false
   }
 }
@@ -165,9 +166,7 @@ export const downloadNoteAsTxt = (note: Note): void => {
   const baseFilename = note.title && note.title.trim() ? note.title.trim() : 'untitled'
   const safeFilename = sanitizeFilename(baseFilename)
   const filename = `${safeFilename}.txt`
-  
-  console.log('Downloading note:', { title: note.title, filename })
-  
+
   const blob = new Blob([content], { type: 'text/plain;charset=utf-8' })
   saveAs(blob, filename)
 }

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -1,10 +1,11 @@
 import { useNotificationStore } from '../stores/notificationStore'
 import { useHabitStore } from '../stores/habitStore'
 import { useTaskStore } from '../stores/taskStore'
+import { logger } from '../utils/logger'
 
 export async function requestNotificationPermission(): Promise<boolean> {
   if (!('Notification' in window)) {
-    console.warn('This browser does not support notifications')
+    logger.warn('This browser does not support notifications')
     return false
   }
   

--- a/src/services/productivityReportService.ts
+++ b/src/services/productivityReportService.ts
@@ -8,6 +8,7 @@ import { useNoteStore } from '../stores/noteStore'
 import { useFocusStore } from '../stores/focusStore'
 import { useGamificationStore } from '../stores/gamificationStore'
 import { useSettingsStore, PROVIDER_INFO } from '../stores/settingsStore'
+import { logger } from '../utils/logger'
 import { useReportStore } from '../stores/reportStore'
 import type {
   ProductivityData,
@@ -502,7 +503,7 @@ function parseAIResponse(
       }
     }
   } catch (e) {
-    console.error('Failed to parse AI response:', e)
+    logger.error('Failed to parse AI response:', e)
   }
 
   // Fallback if parsing fails
@@ -663,7 +664,7 @@ export async function generateProductivityReport(
         reportStore.setGenerationProgress('Processing AI response...')
         reportContent = parseAIResponse(aiResponse, data)
       } catch (aiError) {
-        console.warn('AI report failed, using fallback:', aiError)
+        logger.warn('AI report failed, using fallback:', aiError)
         reportContent = generateFallbackReport(data)
       }
     } else {

--- a/src/services/reportAgentService.ts
+++ b/src/services/reportAgentService.ts
@@ -8,6 +8,7 @@ import { useFocusStore } from '../stores/focusStore'
 import { useGamificationStore } from '../stores/gamificationStore'
 import { useSettingsStore, PROVIDER_INFO } from '../stores/settingsStore'
 import { getWeekRange, getWeekDates } from './analysisService'
+import { logger } from '../utils/logger'
 
 // Tool definitions for Report Agent
 export const REPORT_AGENT_TOOLS = [
@@ -342,7 +343,7 @@ export async function generateReportWithAgent(weekOffset: number = 0): Promise<{
       generatedAt: new Date().toISOString(),
     }
   } catch (error) {
-    console.error('Report Agent error:', error)
+    logger.error('Report Agent error:', error)
     return {
       success: false,
       markdown: `# Error\n\nFailed to generate report: ${error instanceof Error ? error.message : 'Unknown error'}`,

--- a/src/services/updateService.ts
+++ b/src/services/updateService.ts
@@ -3,6 +3,8 @@
  * Checks GitHub Releases for new versions
  */
 
+import { logger } from '../utils/logger';
+
 const GITHUB_REPO = 'samitugal/bytepad';
 const CURRENT_VERSION = '0.24.3';
 const CHECK_INTERVAL = 4 * 60 * 60 * 1000; // 4 hours
@@ -90,7 +92,7 @@ async function fetchLatestRelease(): Promise<ReleaseInfo | null> {
     );
 
     if (!response.ok) {
-      console.warn('[Update] Failed to fetch release:', response.status);
+      logger.warn('[Update] Failed to fetch release:', response.status);
       return null;
     }
 
@@ -113,7 +115,7 @@ async function fetchLatestRelease(): Promise<ReleaseInfo | null> {
       })),
     };
   } catch (error) {
-    console.warn('[Update] Error fetching release:', error);
+    logger.warn('[Update] Error fetching release:', error);
     return null;
   }
 }
@@ -147,11 +149,11 @@ export async function checkForUpdates(force = false): Promise<ReleaseInfo | null
 
   // Check if newer version
   if (release && compareVersions(release.version, CURRENT_VERSION) > 0) {
-    console.log(`[Update] New version available: ${release.version} (current: ${CURRENT_VERSION})`);
+    logger.info(`[Update] New version available: ${release.version} (current: ${CURRENT_VERSION})`);
     return release;
   }
 
-  console.log(`[Update] No updates available (current: ${CURRENT_VERSION})`);
+  logger.info(`[Update] No updates available (current: ${CURRENT_VERSION})`);
   return null;
 }
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,55 @@
+// Shared logging utility for the renderer (src/).
+//
+// Shape mirrors electron/server/utils/logger.ts (debug/info/warn/error with a
+// priority-based level filter) so the codebase has one logger convention
+// instead of two. The renderer ships to end users, so it defaults to a
+// quieter level in production builds and a verbose level in dev, based on
+// Vite's `import.meta.env.DEV` flag.
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error'
+
+const levelPriority: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+}
+
+// Dev: show everything. Prod: only warn/error survive by default, so real
+// problems remain visible (e.g. for users reporting bugs) while routine
+// debug/info tracing stays silent.
+let currentLevel: LogLevel = import.meta.env.DEV ? 'debug' : 'warn'
+
+export function setLogLevel(level: LogLevel) {
+  currentLevel = level
+}
+
+function shouldLog(level: LogLevel): boolean {
+  return levelPriority[level] >= levelPriority[currentLevel]
+}
+
+export const logger = {
+  debug(message: string, ...args: unknown[]) {
+    if (shouldLog('debug')) {
+      console.log(`[DEBUG] ${message}`, ...args)
+    }
+  },
+
+  info(message: string, ...args: unknown[]) {
+    if (shouldLog('info')) {
+      console.log(`[INFO] ${message}`, ...args)
+    }
+  },
+
+  warn(message: string, ...args: unknown[]) {
+    if (shouldLog('warn')) {
+      console.warn(`[WARN] ${message}`, ...args)
+    }
+  },
+
+  error(message: string, ...args: unknown[]) {
+    if (shouldLog('error')) {
+      console.error(`[ERROR] ${message}`, ...args)
+    }
+  },
+}


### PR DESCRIPTION
Adds a logger for the renderer mirroring the one the server already uses, and routes existing console calls through it. Quiet by default in production builds, verbose in development.