### PR TITLE
chore: bump version to 0.25.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![License](https://img.shields.io/badge/license-Personal%20Use-blue)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey)](#download)
-[![Version](https://img.shields.io/badge/version-0.24.3-green)](https://github.com/samitugal/bytepad/releases)
+[![Version](https://img.shields.io/badge/version-0.25.0-green)](https://github.com/samitugal/bytepad/releases)
 
 
 bytepad is a keyboard-first, privacy-first productivity app built for people who think better in plain text.
@@ -162,7 +162,7 @@ Or use docker-compose:
 ```yaml
 services:
   bytepad-mcp:
-    image: bytepad/mcp-server:0.24.3
+    image: bytepad/mcp-server:0.25.0
     ports:
       - "3847:3847"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     build:
       context: ./docker/mcp-server
       dockerfile: Dockerfile
-    image: bytepad/mcp-server:0.24.3
+    image: bytepad/mcp-server:0.25.0
     container_name: bytepad-mcp
     ports:
       # Bound to localhost only by default - the container is not reachable

--- a/docker/mcp-server/package.json
+++ b/docker/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bytepad-mcp-server",
-  "version": "0.24.3",
+  "version": "0.25.0",
   "description": "Standalone MCP Server for bytepad",
   "type": "module",
   "main": "dist/server.js",

--- a/docker/mcp-server/src/routes.ts
+++ b/docker/mcp-server/src/routes.ts
@@ -24,7 +24,7 @@ export function createRoutes(storeBridge: StoreBridge): Router {
       success: true,
       status: 'healthy',
       service: 'bytepad-mcp-docker',
-      version: '0.24.3',
+      version: '0.25.0',
       timestamp: new Date().toISOString(),
     });
   });

--- a/docker/mcp-server/src/server.ts
+++ b/docker/mcp-server/src/server.ts
@@ -72,7 +72,7 @@ setInterval(() => {
 // Create MCP server with tools and resources
 function createMCPServer(): Server {
   const server = new Server(
-    { name: 'bytepad', version: '0.24.3' },
+    { name: 'bytepad', version: '0.25.0' },
     { capabilities: { resources: {}, tools: {} } }
   );
 
@@ -353,7 +353,7 @@ async function startServer(): Promise<void> {
       success: true,
       status: 'healthy',
       service: 'bytepad-mcp-docker',
-      version: process.env.npm_package_version || '0.24.3',
+      version: process.env.npm_package_version || '0.25.0',
       timestamp: new Date().toISOString(),
       uptime: process.uptime(),
     });

--- a/electron/server/mcp/index.ts
+++ b/electron/server/mcp/index.ts
@@ -57,7 +57,7 @@ export function createMCPServer(): Server {
   const server = new Server(
     {
       name: 'bytepad',
-      version: '0.24.3',
+      version: '0.25.0',
     },
     {
       capabilities: {

--- a/electron/services/dockerService.ts
+++ b/electron/services/dockerService.ts
@@ -18,7 +18,7 @@ const store = new Store();
 
 const CONTAINER_NAME = 'bytepad-mcp';
 const IMAGE_NAME = 'bytepad/mcp-server';
-const IMAGE_TAG = '0.24.3';
+const IMAGE_TAG = '0.25.0';
 
 /**
  * Single definition of the "image missing" guidance shown to users.

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/sami-macstation/Documents/Projects/bytepad/node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bytepad",
-  "version": "0.24.3",
+  "version": "0.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bytepad",
-      "version": "0.24.3",
+      "version": "0.25.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bytepad",
   "private": true,
-  "version": "0.24.3",
+  "version": "0.25.0",
   "description": "A modern productivity app for notes, tasks, habits, and journaling",
   "author": {
     "name": "Sami Tugal",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for bytepad PWA
 // Version-based cache for automatic updates
-const APP_VERSION = '0.23.2';
+const APP_VERSION = '0.25.0';
 const CACHE_NAME = `bytepad-${APP_VERSION}`;
 
 const STATIC_ASSETS = [

--- a/src/components/common/SettingsPanel.tsx
+++ b/src/components/common/SettingsPanel.tsx
@@ -291,7 +291,7 @@ export function SettingsPanel({ isOpen, onClose }: SettingsPanelProps) {
 
                 {/* Footer */}
                 <div className="px-4 py-2 border-t border-np-border text-xs text-np-text-secondary flex justify-between shrink-0">
-                    <span>bytepad v0.24.3</span>
+                    <span>bytepad v0.25.0</span>
                     <span>Ctrl+, to open settings</span>
                 </div>
             </div>

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -58,7 +58,7 @@ export function StatusBar() {
             <span>⚡</span> {language === 'tr' ? 'Çevrimdışı' : 'Offline'}
           </span>
         )}
-        <span>bytepad v0.24.3</span>
+        <span>bytepad v0.25.0</span>
       </div>
     </div>
   )

--- a/src/services/updateService.ts
+++ b/src/services/updateService.ts
@@ -6,7 +6,7 @@
 import { logger } from '../utils/logger';
 
 const GITHUB_REPO = 'samitugal/bytepad';
-const CURRENT_VERSION = '0.24.3';
+const CURRENT_VERSION = '0.25.0';
 const CHECK_INTERVAL = 4 * 60 * 60 * 1000; // 4 hours
 const CACHE_KEY = 'bytepad-update-check';
 


### PR DESCRIPTION
Version bump across the app, container server, docs badge and service worker cache key.