### PR TITLE
chore(settings): remove the email delivery configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
-        "@emailjs/browser": "^4.4.1",
         "@langchain/anthropic": "^1.5.2",
         "@langchain/core": "^1.2.4",
         "@langchain/openai": "^1.2.1",
@@ -855,15 +854,6 @@
       "peer": true,
       "engines": {
         "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@emailjs/browser": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@emailjs/browser/-/browser-4.4.1.tgz",
-      "integrity": "sha512-DGSlP9sPvyFba3to2A50kDtZ+pXVp/0rhmqs2LmbMS3I5J8FSOgLwzY2Xb4qfKlOVHh29EAutLYwe5yuEZmEFg==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@emailjs/browser": "^4.4.1",
     "@langchain/anthropic": "^1.5.2",
     "@langchain/core": "^1.2.4",
     "@langchain/openai": "^1.2.1",

--- a/src/components/common/SettingsPanel.tsx
+++ b/src/components/common/SettingsPanel.tsx
@@ -586,8 +586,6 @@ function IntegrationsTab({
     emailPreferences: {
         enabled: boolean
         userEmail: string
-        emailjsServiceId: string
-        emailjsPublicKey: string
         dailySummaryEnabled: boolean
         dailySummaryTime: string
         weeklySummaryEnabled: boolean
@@ -689,33 +687,6 @@ function IntegrationsTab({
                                     className="w-full bg-np-bg-primary border border-np-border text-np-text-primary 
                              font-mono text-sm px-2 py-1.5 focus:outline-none focus:border-np-blue"
                                 />
-                            </div>
-
-                            <div className="pt-2 border-t border-np-border">
-                                <p className="text-xs text-np-text-secondary mb-2">
-                                    EmailJS Configuration -{' '}
-                                    <a href="https://emailjs.com" target="_blank" rel="noopener" className="text-np-blue hover:underline">
-                                        emailjs.com
-                                    </a>
-                                </p>
-                                <div className="grid grid-cols-2 gap-2">
-                                    <input
-                                        type="text"
-                                        value={emailPreferences.emailjsServiceId}
-                                        onChange={(e) => setEmailPreferences({ emailjsServiceId: e.target.value })}
-                                        placeholder="Service ID"
-                                        className="bg-np-bg-primary border border-np-border text-np-text-primary 
-                               font-mono text-xs px-2 py-1 focus:outline-none focus:border-np-blue"
-                                    />
-                                    <input
-                                        type="text"
-                                        value={emailPreferences.emailjsPublicKey}
-                                        onChange={(e) => setEmailPreferences({ emailjsPublicKey: e.target.value })}
-                                        placeholder="Public Key"
-                                        className="bg-np-bg-primary border border-np-border text-np-text-primary 
-                               font-mono text-xs px-2 py-1 focus:outline-none focus:border-np-blue"
-                                    />
-                                </div>
                             </div>
 
                             <div className="space-y-2">

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -89,7 +89,6 @@
             "quietHours": "Quiet Hours",
             "emailNotifications": "Email Notifications",
             "yourEmail": "Your Email",
-            "emailjsConfig": "EmailJS Configuration",
             "dailySummary": "Daily summary email",
             "weeklyReport": "Weekly report email",
             "streakAlerts": "Streak risk alerts"

--- a/src/i18n/tr.json
+++ b/src/i18n/tr.json
@@ -89,7 +89,6 @@
             "quietHours": "Sessiz Saatler",
             "emailNotifications": "E-posta Bildirimleri",
             "yourEmail": "E-posta Adresiniz",
-            "emailjsConfig": "EmailJS Yapılandırması",
             "dailySummary": "Günlük özet e-postası",
             "weeklyReport": "Haftalık rapor e-postası",
             "streakAlerts": "Seri risk uyarıları"

--- a/src/services/ipcStoreService.ts
+++ b/src/services/ipcStoreService.ts
@@ -286,13 +286,13 @@ const storeAccessors: Record<StoreName, {
   },
 };
 
-// The settings store carries secrets (LLM API keys, GitHub sync token,
-// EmailJS public key) alongside its regular preferences. Nothing on the
-// bridge/MCP-server side legitimately needs the raw secret values (gist sync,
-// for instance, only reads `gistSync.enabled`/`gistId` via this bridge — the
-// actual sync call is made from the renderer, which already has the real
-// token in memory). Redact secrets before handing the settings snapshot out
-// over IPC so a compromised MCP client/consumer can't read them wholesale.
+// The settings store carries secrets (LLM API keys, GitHub sync token)
+// alongside its regular preferences. Nothing on the bridge/MCP-server side
+// legitimately needs the raw secret values (gist sync, for instance, only
+// reads `gistSync.enabled`/`gistId` via this bridge — the actual sync call
+// is made from the renderer, which already has the real token in memory).
+// Redact secrets before handing the settings snapshot out over IPC so a
+// compromised MCP client/consumer can't read them wholesale.
 const REDACTED = '[redacted]';
 
 function sanitizeSettingsForBridge(state: ReturnType<typeof useSettingsStore.getState>) {
@@ -307,10 +307,7 @@ function sanitizeSettingsForBridge(state: ReturnType<typeof useSettingsStore.get
     fontFamily: state.fontFamily,
     noteMarkdownPreview: state.noteMarkdownPreview,
     noteFontSize: state.noteFontSize,
-    emailPreferences: {
-      ...state.emailPreferences,
-      emailjsPublicKey: state.emailPreferences.emailjsPublicKey ? REDACTED : '',
-    },
+    emailPreferences: state.emailPreferences,
     gistSync: {
       ...state.gistSync,
       githubToken: state.gistSync.githubToken ? REDACTED : '',

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -173,11 +173,6 @@ export interface FocusPreferences {
 export interface EmailPreferences {
   enabled: boolean
   userEmail: string
-  emailjsServiceId: string
-  emailjsPublicKey: string
-  emailjsTemplateDaily: string
-  emailjsTemplateWeekly: string
-  emailjsTemplateStreak: string
   dailySummaryEnabled: boolean
   dailySummaryTime: string // HH:mm format
   weeklySummaryEnabled: boolean
@@ -208,10 +203,10 @@ interface SettingsState {
   // GitHub Gist Sync
   gistSync: GistSyncPreferences
 
-  // Web-only opt-in: persist secrets (apiKeys, gistSync.githubToken,
-  // emailPreferences.emailjsPublicKey) to localStorage instead of the
-  // sessionStorage-only default. Always false in Electron, where
-  // safeStorage-backed encryption covers this instead (see storage.ts).
+  // Web-only opt-in: persist secrets (apiKeys, gistSync.githubToken) to
+  // localStorage instead of the sessionStorage-only default. Always false
+  // in Electron, where safeStorage-backed encryption covers this instead
+  // (see storage.ts).
   rememberSecretsOnDevice: boolean
 
   // Focus Mode Settings
@@ -257,56 +252,90 @@ interface SettingsState {
 }
 
 // --- Secret handling -------------------------------------------------------
-// apiKeys, gistSync.githubToken and emailPreferences.emailjsPublicKey are
-// intentionally excluded from the zustand `persist` blob below (see
-// `partialize`) and are instead mirrored to `secretsStorage` (Electron:
-// electron-store via a safeStorage-encrypted IPC channel, Web:
-// sessionStorage by default, or localStorage if the user opts in via
-// `setRememberSecretsOnDevice` — see src/utils/storage.ts). This keeps the
-// runtime store shape and every existing call site (`state.apiKeys[...]`,
-// `getCurrentApiKey()`, etc.) unchanged; only where these three fields end
-// up at rest on disk changes.
-function buildSecretsPayload(state: Pick<SettingsState, 'apiKeys' | 'gistSync' | 'emailPreferences'>): StoredSecrets {
+// apiKeys and gistSync.githubToken are intentionally excluded from the
+// zustand `persist` blob below (see `partialize`) and are instead mirrored
+// to `secretsStorage` (Electron: electron-store via a safeStorage-encrypted
+// IPC channel, Web: sessionStorage by default, or localStorage if the user
+// opts in via `setRememberSecretsOnDevice` — see src/utils/storage.ts).
+// This keeps the runtime store shape and every existing call site
+// (`state.apiKeys[...]`, `getCurrentApiKey()`, etc.) unchanged; only where
+// these fields end up at rest on disk changes.
+function buildSecretsPayload(state: Pick<SettingsState, 'apiKeys' | 'gistSync'>): StoredSecrets {
   return {
     apiKeys: state.apiKeys,
     githubToken: state.gistSync.githubToken,
-    emailjsPublicKey: state.emailPreferences.emailjsPublicKey,
   }
+}
+
+// Fields that used to live on EmailPreferences to configure EmailJS (now
+// removed entirely — there is no send path left anywhere in the app).
+// Existing installs may still have these sitting in the persisted settings
+// blob (plaintext localStorage) from before removal; `emailjsPublicKey`
+// specifically may also still be sitting in secretsStorage (safeStorage
+// encrypted on desktop, session/local storage on web), since it used to be
+// mirrored there as a secret. Both are cleared by migrateAndLoadSecrets.
+const LEGACY_EMAILJS_FIELDS = [
+  'emailjsServiceId',
+  'emailjsPublicKey',
+  'emailjsTemplateDaily',
+  'emailjsTemplateWeekly',
+  'emailjsTemplateStreak',
+] as const
+
+function stripLegacyEmailjsFields(prefs: EmailPreferences): EmailPreferences {
+  const clean = { ...prefs } as EmailPreferences & Record<string, unknown>
+  for (const key of LEGACY_EMAILJS_FIELDS) {
+    delete clean[key]
+  }
+  return clean
 }
 
 let secretsMigrationRan = false
 
 // Runs once per app session after the settings store rehydrates.
+// - Always scrubs any legacy EmailJS fields left on emailPreferences from
+//   before that surface was removed (service id, public key, unused
+//   templates). This alone is a `set` call, so it also triggers a persist
+//   re-write that drops those keys from the localStorage blob.
 // - If secretsStorage already has a record, it wins (it's the source of
 //   truth going forward) and is applied over whatever hydration produced.
+//   If that record still carries an orphaned emailjsPublicKey from before
+//   removal, it's re-saved via buildSecretsPayload (which no longer knows
+//   about that field) — secretsStorage.save always overwrites the whole
+//   record, so this is what actually deletes the stale value rather than
+//   merely stopping future writes of it.
 // - Otherwise, if the persisted localStorage blob still carries plaintext
 //   secrets from before this change, migrate them into secretsStorage.
 // - Either way, force one persist write so `partialize` (which no longer
 //   writes secret values) overwrites any legacy plaintext left on disk.
-// Idempotent: once secretsStorage has a record, subsequent runs just apply it.
+// Idempotent: once secretsStorage has a record and emailPreferences is
+// clean, subsequent runs are no-ops beyond re-applying the same values.
 async function migrateAndLoadSecrets() {
   if (secretsMigrationRan) return
   secretsMigrationRan = true
 
   const state = useSettingsStore.getState()
-  const stored = await secretsStorage.load()
+  const stored = await secretsStorage.load() as (StoredSecrets & { emailjsPublicKey?: string }) | null
+
+  const hasLegacyEmailjsFields = LEGACY_EMAILJS_FIELDS.some((key) => key in state.emailPreferences)
+  if (hasLegacyEmailjsFields) {
+    useSettingsStore.setState((s) => ({ emailPreferences: stripLegacyEmailjsFields(s.emailPreferences) }))
+  }
 
   if (stored) {
     useSettingsStore.setState((s) => ({
       apiKeys: { ...s.apiKeys, ...(stored.apiKeys || {}) },
       gistSync: { ...s.gistSync, githubToken: stored.githubToken ?? s.gistSync.githubToken },
-      emailPreferences: {
-        ...s.emailPreferences,
-        emailjsPublicKey: stored.emailjsPublicKey ?? s.emailPreferences.emailjsPublicKey,
-      },
     }))
+    if ('emailjsPublicKey' in stored) {
+      await secretsStorage.save(buildSecretsPayload(useSettingsStore.getState()))
+    }
     return
   }
 
   const hasLegacySecrets =
     Object.values(state.apiKeys).some(Boolean) ||
-    !!state.gistSync.githubToken ||
-    !!state.emailPreferences.emailjsPublicKey
+    !!state.gistSync.githubToken
 
   if (hasLegacySecrets) {
     await secretsStorage.save(buildSecretsPayload(state))
@@ -340,11 +369,6 @@ export const useSettingsStore = create<SettingsState>()(
       emailPreferences: {
         enabled: false,
         userEmail: '',
-        emailjsServiceId: '',
-        emailjsPublicKey: '',
-        emailjsTemplateDaily: '',
-        emailjsTemplateWeekly: '',
-        emailjsTemplateStreak: '',
         dailySummaryEnabled: false,
         dailySummaryTime: '20:00',
         weeklySummaryEnabled: false,
@@ -417,9 +441,6 @@ export const useSettingsStore = create<SettingsState>()(
         set((state) => ({
           emailPreferences: { ...state.emailPreferences, ...prefs }
         }))
-        if ('emailjsPublicKey' in prefs) {
-          void secretsStorage.save(buildSecretsPayload(get()))
-        }
       },
 
       setGistSync: (prefs) => {
@@ -472,10 +493,10 @@ export const useSettingsStore = create<SettingsState>()(
     }),
     {
       name: 'bytepad-settings',
-      // Persist settings, but NOT secrets (apiKeys, gistSync.githubToken,
-      // emailPreferences.emailjsPublicKey). Those are mirrored separately via
-      // `secretsStorage` (see migrateAndLoadSecrets/buildSecretsPayload
-      // above) so they never land in this plaintext localStorage blob.
+      // Persist settings, but NOT secrets (apiKeys, gistSync.githubToken).
+      // Those are mirrored separately via `secretsStorage` (see
+      // migrateAndLoadSecrets/buildSecretsPayload above) so they never land
+      // in this plaintext localStorage blob.
       partialize: (state) => ({
         llmProvider: state.llmProvider,
         llmModel: state.llmModel,
@@ -484,7 +505,7 @@ export const useSettingsStore = create<SettingsState>()(
         fontFamily: state.fontFamily,
         noteMarkdownPreview: state.noteMarkdownPreview,
         noteFontSize: state.noteFontSize,
-        emailPreferences: { ...state.emailPreferences, emailjsPublicKey: '' },
+        emailPreferences: state.emailPreferences,
         gistSync: { ...state.gistSync, githubToken: '' },
         focusPreferences: state.focusPreferences,
         gamificationEnabled: state.gamificationEnabled,
@@ -496,11 +517,13 @@ export const useSettingsStore = create<SettingsState>()(
       }),
       // Merge persisted state with initial state to handle new fields.
       // Note: persistedState may still carry legacy plaintext apiKeys /
-      // gistSync.githubToken / emailPreferences.emailjsPublicKey from
-      // pre-fix installs (this old data isn't deleted out from under the
-      // user); migrateAndLoadSecrets() picks those up right after hydration,
-      // moves them into secretsStorage, and triggers a re-write that scrubs
-      // them from this blob going forward.
+      // gistSync.githubToken from pre-fix installs, or legacy
+      // emailPreferences.emailjsServiceId / emailjsPublicKey fields from
+      // before the EmailJS surface was removed (this old data isn't
+      // deleted out from under the user); migrateAndLoadSecrets() picks
+      // those up right after hydration, moves the secret ones into
+      // secretsStorage, and triggers a re-write that scrubs all of them
+      // from this blob going forward.
       merge: (persistedState, currentState) => ({
         ...currentState,
         ...(persistedState as Partial<SettingsState>),

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -75,7 +75,6 @@ const REMEMBER_ON_DEVICE_KEY = 'bytepad-secrets-remember'
 export interface StoredSecrets {
   apiKeys?: Record<string, string>
   githubToken?: string
-  emailjsPublicKey?: string
 }
 
 // Web-only: whether the user opted in to persisting secrets to localStorage.


### PR DESCRIPTION
Removes a configuration form for a delivery path that no longer exists, along with its dependency, and clears the values it had stored for existing users.