### PR TITLE
chore: stop tracking the node_modules path and widen the ignore rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ pnpm-debug.log*
 lerna-debug.log*
 
 # Dependencies
-node_modules/
+node_modules
 
 # Build output
 dist/

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/sami-macstation/Documents/Projects/bytepad/node_modules


### PR DESCRIPTION
A symlink named node_modules was committed because the ignore pattern ended in a slash and therefore matched directories only. Removes it from the index and drops the slash.