### PR TITLE
feat(settings): state when cloud sync requires your own Firebase project

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ Over time, these links form a personal knowledge graph that reflects how you act
 - **Focus Mode** - Pomodoro timer with customizable work/break intervals
 - **Gamification** - XP, levels, and achievements to stay motivated
 - **Localization** - English and Turkish language support
-- **GitHub Gist Sync** - Optional cloud backup to private Gist
+- **GitHub Gist Sync** - Cross-device sync out of the box, backed by a private Gist
+- **Cloud Sync (bring your own Firebase)** - Google sign-in and Firestore sync, if you connect your own Firebase project. Not configured in downloaded builds — see [docs/features/cloud-sync.md](docs/features/cloud-sync.md)
 - **MCP Server** - Model Context Protocol integration for AI assistants (Claude Desktop, Cursor, etc.)
 
 ---
@@ -226,7 +227,7 @@ bytepad is designed for keyboard-first navigation. Press `Ctrl+?` anytime to see
 ## Privacy
 
 - All data stored locally on your device
-- No external servers (except optional Gist sync)
+- No external servers by default (Gist sync uses your GitHub account; cloud sync, if you configure your own Firebase project, uses that project)
 - AI features only send necessary context to your chosen provider
 - API keys stored locally, never transmitted
 - MCP server runs locally - your data never leaves your machine

--- a/docs/features/cloud-sync.md
+++ b/docs/features/cloud-sync.md
@@ -1,0 +1,32 @@
+# Cloud Sync (Bring Your Own Firebase)
+
+Downloaded bytepad builds ship with Firebase unconfigured, on purpose. There is no shared bytepad backend — running one for every downloader would mean taking on hosting, quota, and data-stewardship for other people's data, which isn't part of the v1 plan. Instead, cloud sync and Google sign-in are available to anyone willing to connect their own Firebase project.
+
+If you just want sync working without any setup, use **[Gist Sync](./sync.md)** — it works out of the box with nothing but a GitHub token.
+
+Cloud sync is the alternative for people who want Google sign-in and real-time Firestore sync backed by infrastructure they control.
+
+## Setup
+
+1. **Configure environment variables.** Copy [`.env.example`](../../.env.example) (repo root) to `.env` and fill in the `VITE_FIREBASE_*` values. That file's "Firebase Setup Steps" comment walks through creating the Firebase project, enabling Google sign-in, and enabling Firestore — follow it in order.
+2. **Deploy the Firestore rules.** Still following `.env.example`'s steps, deploy [`firestore.rules`](../../firestore.rules) (repo root) to your project before storing any real data. The rules restrict every document to the signed-in user's own `uid`.
+3. **(Optional) Pin the Firebase CLI project.** Copy [`.firebaserc.example`](../../.firebaserc.example) to `.firebaserc` and set your project id, so `firebase deploy` doesn't need a `--project` flag every time. `.firebaserc` is gitignored — it stays local to you.
+4. **Restart bytepad.** Environment variables are read at build/start time, so restart `npm run dev` (or rebuild the app) after saving `.env`.
+
+Once these values are present, `isConfigured()` in `src/services/firebase.ts` flips to `true`: the "cloud sync is disabled" note in Settings disappears, and both Google sign-in and Firestore sync become available.
+
+## What you get
+
+- Google sign-in
+- Firestore-backed sync across devices, in addition to (not instead of) Gist Sync
+
+## Data ownership
+
+The Firebase project is yours — created under your own Google account, billed to you (Firebase's free tier covers typical personal use), and accessible only with your credentials. bytepad never sees your Firebase keys or your data; they stay in your `.env` and your Firestore instance.
+
+## See also
+
+- [`.env.example`](../../.env.example) — the full list of `VITE_FIREBASE_*` variables and setup steps
+- [`.firebaserc.example`](../../.firebaserc.example) — Firebase CLI project template
+- [Gist Sync](./sync.md) — the sync path that works without any setup
+- [Configuration](../getting-started/configuration.md) — general settings reference

--- a/src/components/common/SettingsPanel.tsx
+++ b/src/components/common/SettingsPanel.tsx
@@ -758,15 +758,27 @@ function SyncTab({
     signIn: () => void
     signOut: () => void
 }) {
+    const { t } = useTranslation()
+
     return (
         <div className="space-y-6">
             {/* Google Account */}
             <div>
                 <h3 className="text-sm text-np-green mb-3">// Google Account</h3>
                 {!authConfigured ? (
-                    <div className="text-xs text-np-text-secondary bg-np-bg-tertiary p-3 border border-np-border">
-                        <p className="mb-2">Google Sign-in is not configured.</p>
-                        <p>Add Firebase config to <code className="text-np-cyan">.env</code> file.</p>
+                    <div className="text-xs text-np-text-secondary bg-np-bg-tertiary p-3 border border-np-border space-y-2">
+                        <p>{t('settings.sync.notConfigured')}</p>
+                        <p>{t('settings.sync.addFirebaseConfig')}</p>
+                        <p>
+                            <a
+                                href="https://github.com/samitugal/bytepad/blob/main/docs/features/cloud-sync.md"
+                                target="_blank"
+                                rel="noopener"
+                                className="text-np-blue hover:underline"
+                            >
+                                {t('settings.sync.cloudSyncGuideLink')}
+                            </a>
+                        </p>
                     </div>
                 ) : user ? (
                     <div className="flex items-center justify-between bg-np-bg-tertiary p-3 border border-np-border">

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -95,8 +95,9 @@
         },
         "sync": {
             "googleAccount": "Google Account",
-            "notConfigured": "Google Sign-in is not configured.",
-            "addFirebaseConfig": "Add Firebase config to",
+            "notConfigured": "Cloud sync and Google sign-in are disabled in this build.",
+            "addFirebaseConfig": "To enable them, connect your own Firebase project — bytepad doesn't ship with a shared backend.",
+            "cloudSyncGuideLink": "See the setup guide",
             "signOut": "Sign Out",
             "signInWithGoogle": "Sign in with Google",
             "signingIn": "Signing in...",

--- a/src/i18n/tr.json
+++ b/src/i18n/tr.json
@@ -95,8 +95,9 @@
         },
         "sync": {
             "googleAccount": "Google Hesabı",
-            "notConfigured": "Google girişi yapılandırılmamış.",
-            "addFirebaseConfig": "Firebase yapılandırmasını ekleyin:",
+            "notConfigured": "Bu derlemede bulut senkronizasyonu ve Google ile giriş devre dışı.",
+            "addFirebaseConfig": "Bunları etkinleştirmek için kendi Firebase projenizi bağlayın — bytepad paylaşılan bir backend ile gelmez.",
+            "cloudSyncGuideLink": "Kurulum kılavuzuna bakın",
             "signOut": "Çıkış Yap",
             "signInWithGoogle": "Google ile Giriş Yap",
             "signingIn": "Giriş yapılıyor...",


### PR DESCRIPTION
Downloaded builds ship without a Firebase configuration, so cloud sync and Google sign-in are unavailable in them. Settings now says so and links a setup guide; the README distinguishes Gist sync as the out-of-box path.