### PR TITLE
fix(ui): resolve tab labels through the shared module map

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -5,6 +5,7 @@ import { useJournalStore } from '../../stores/journalStore'
 import { useBookmarkStore } from '../../stores/bookmarkStore'
 import { useDailyNotesStore } from '../../stores/dailyNotesStore'
 import { useTranslation } from '../../i18n'
+import { getModuleLabel } from '../../i18n/moduleLabels'
 import type { ModuleType } from '../../types'
 
 const MODULE_IDS: { id: ModuleType; shortcut: string }[] = [
@@ -68,22 +69,6 @@ export function Sidebar() {
       .map(([tag, count]) => ({ tag, count }))
   }, [notes, journalEntries, bookmarks, dailyNotes])
   
-  // Map module IDs to translated labels
-  const getModuleLabel = (id: ModuleType): string => {
-    const labelMap: Record<ModuleType, string> = {
-      notes: t('nav.notes'),
-      dailynotes: t('dailyNotes.title'),
-      ideas: t('ideas.title'),
-      habits: t('nav.habits'),
-      tasks: t('nav.tasks'),
-      journal: t('nav.journal'),
-      bookmarks: t('nav.bookmarks'),
-      calendar: t('nav.calendar'),
-      graph: t('nav.graph'),
-      analysis: t('nav.analysis'),
-    }
-    return labelMap[id] || id
-  }
   const [width, setWidth] = useState(() => {
     const saved = localStorage.getItem('bytepad-sidebar-width')
     return saved ? parseInt(saved, 10) : DEFAULT_WIDTH
@@ -142,7 +127,7 @@ export function Sidebar() {
                 : 'text-np-text-secondary hover:bg-np-bg-tertiary hover:text-np-text-primary'
             }`}
           >
-            <span className="truncate">{activeModule === module.id ? '>' : ' '} {getModuleLabel(module.id)}</span>
+            <span className="truncate">{activeModule === module.id ? '>' : ' '} {getModuleLabel(t, module.id)}</span>
             <span className="text-xs text-np-text-secondary flex-shrink-0">^{module.shortcut}</span>
           </button>
         ))}

--- a/src/components/layout/TabBar.tsx
+++ b/src/components/layout/TabBar.tsx
@@ -3,6 +3,7 @@ import { useUIStore } from '../../stores/uiStore'
 import { useTabStore, Tab } from '../../stores/tabStore'
 import { useNoteStore } from '../../stores/noteStore'
 import { useTranslation } from '../../i18n'
+import { getModuleLabel } from '../../i18n/moduleLabels'
 
 const TAB_ICONS: Record<string, string> = {
   note: '📝',
@@ -76,7 +77,7 @@ export function TabBar() {
       <div className="h-8 bg-np-bg-tertiary border-b border-np-border flex items-center px-1">
         <div className="flex items-center">
           <div className="px-3 py-1 bg-np-bg-primary border-t border-l border-r border-np-border text-np-text-primary text-sm flex items-center gap-2">
-            <span>{t(`nav.${activeModule}`) || activeModule}</span>
+            <span>{getModuleLabel(t, activeModule)}</span>
             <span className="text-np-text-secondary text-xs">×</span>
           </div>
           <button 

--- a/src/i18n/moduleLabels.ts
+++ b/src/i18n/moduleLabels.ts
@@ -1,0 +1,33 @@
+import type { ModuleType } from '../types'
+
+/**
+ * Single source of truth for module -> display label.
+ *
+ * Sidebar and TabBar both need a human-readable name for a ModuleType.
+ * Deriving the i18n key from the module id by string manipulation (e.g.
+ * `nav.${id}`) breaks silently: some modules key off `nav.*` (lowercase,
+ * matches the id) while others key off a dedicated section with different
+ * casing (`dailynotes` -> `dailyNotes.title`, `ideas` -> `ideas.title`).
+ * A missing/mismatched key doesn't throw - getNestedValue() in ./index.ts
+ * returns the raw key path, which is truthy, so `t(key) || id` fallbacks
+ * never engage either.
+ *
+ * Keeping this map as `Record<ModuleType, string>` makes an unmapped
+ * module a compile error instead of a silently-wrong label at runtime:
+ * adding a case to ModuleType without adding it here fails `tsc -b`.
+ */
+export function getModuleLabel(t: (key: string) => string, id: ModuleType): string {
+  const labels: Record<ModuleType, string> = {
+    notes: t('nav.notes'),
+    dailynotes: t('dailyNotes.title'),
+    ideas: t('ideas.title'),
+    habits: t('nav.habits'),
+    tasks: t('nav.tasks'),
+    journal: t('nav.journal'),
+    bookmarks: t('nav.bookmarks'),
+    calendar: t('nav.calendar'),
+    graph: t('nav.graph'),
+    analysis: t('nav.analysis'),
+  }
+  return labels[id]
+}


### PR DESCRIPTION
Two tabs rendered their key path instead of a label because the key was built from the module id and two modules key off a differently-cased section. Both the sidebar and the tab bar now read from one typed map, so an unmapped module is a compile error.