### PR TITLE
fix(ui): fall back to the raw value on dynamically keyed labels

### DIFF
--- a/src/components/calendar/CalendarModule.tsx
+++ b/src/components/calendar/CalendarModule.tsx
@@ -298,9 +298,9 @@ export function CalendarModule() {
                     ? 'bg-np-blue text-white'
                     : 'bg-np-bg-primary text-np-text-secondary hover:bg-np-bg-tertiary'
                 }`}
-                title={`${t(`calendar.${view}`)} (${view[0].toUpperCase()})`}
+                title={`${t(`calendar.${view}`) || view} (${view[0].toUpperCase()})`}
               >
-                {t(`calendar.${view}`)}
+                {t(`calendar.${view}`) || view}
               </button>
             ))}
           </div>

--- a/src/components/ideas/IdeasModule.tsx
+++ b/src/components/ideas/IdeasModule.tsx
@@ -113,7 +113,7 @@ export function IdeasModule() {
               onClick={() => setFilter(f)}
               className={`px-2 py-0.5 ${filter === f ? 'bg-np-selection text-np-text-primary' : 'text-np-text-secondary hover:text-np-text-primary'}`}
             >
-              {t(`ideas.${f}`)}
+              {t(`ideas.${f}`) || f}
             </button>
           ))}
         </div>

--- a/src/components/tasks/TaskFilters.tsx
+++ b/src/components/tasks/TaskFilters.tsx
@@ -21,7 +21,7 @@ export function TaskFilters({ filter, sortBy, onFilterChange, onSortChange, t }:
             onClick={() => onFilterChange(f)}
             className={`px-2 py-0.5 ${filter === f ? 'bg-np-selection text-np-text-primary' : 'text-np-text-secondary hover:text-np-text-primary'}`}
           >
-            {t(`tasks.${f}`)}
+            {t(`tasks.${f}`) || f}
           </button>
         ))}
       </div>
@@ -33,7 +33,7 @@ export function TaskFilters({ filter, sortBy, onFilterChange, onSortChange, t }:
             onClick={() => onSortChange(s)}
             className={`px-2 py-0.5 ${sortBy === s ? 'bg-np-selection text-np-text-primary' : 'text-np-text-secondary hover:text-np-text-primary'}`}
           >
-            {s === 'manual' ? (t('tasks.manual') || 'Manual') : t(`tasks.${s}`)}
+            {s === 'manual' ? (t('tasks.manual') || 'Manual') : (t(`tasks.${s}`) || s)}
           </button>
         ))}
       </div>


### PR DESCRIPTION
Five filter and view labels build their translation key from a variable. If one is ever added without its translation the control would render blank; it now shows the variable instead.