### PR TITLE
feat: highlight global search matches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,9 @@ jobs:
       - name: Typecheck
         run: npx tsc -b
 
+      - name: Test search highlighting
+        run: npm run test:highlight
+
       # docker/mcp-server is a separate, independently-versioned package
       # (its own express 4 vs the app's express 5, its own @types/node 20)
       # that only ever builds inside the Docker build context copying just

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "package:all": "electron-vite build && electron-builder --win --mac",
     "release": "electron-vite build && electron-builder --win --mac --publish never",
     "lint": "eslint .",
-    "test:highlight": "node --experimental-strip-types scripts/test-highlight-match.mjs",
+    "test:highlight": "node scripts/test-highlight-match.mjs",
     "check:i18n": "node scripts/check-i18n-keys.js",
     "check:version": "node scripts/check-version.js",
     "version:bump": "node scripts/bump-version.js",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "package:all": "electron-vite build && electron-builder --win --mac",
     "release": "electron-vite build && electron-builder --win --mac --publish never",
     "lint": "eslint .",
+    "test:highlight": "node --experimental-strip-types scripts/test-highlight-match.mjs",
     "check:i18n": "node scripts/check-i18n-keys.js",
     "check:version": "node scripts/check-version.js",
     "version:bump": "node scripts/bump-version.js",

--- a/scripts/test-highlight-match.mjs
+++ b/scripts/test-highlight-match.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { getHighlightParts } from '../src/components/common/highlightMatch.ts'
+import { getHighlightParts } from '../src/components/common/highlightMatch.mjs'
 
 const highlighted = (text, query) => getHighlightParts(text, query).filter((part) => part.highlighted).map((part) => part.text)
 

--- a/scripts/test-highlight-match.mjs
+++ b/scripts/test-highlight-match.mjs
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict'
+import { getHighlightParts } from '../src/components/common/highlightMatch.ts'
+
+const highlighted = (text, query) => getHighlightParts(text, query).filter((part) => part.highlighted).map((part) => part.text)
+
+assert.deepEqual(highlighted('Alpha beta alpha', 'alpha'), ['Alpha', 'alpha'])
+assert.deepEqual(highlighted('file [name].txt', '[name]'), ['[name]'])
+assert.deepEqual(highlighted('No matching text', 'zzz'), [])
+assert.deepEqual(highlighted('Taggable note', '#taggable'), ['Taggable'])
+assert.deepEqual(getHighlightParts('plain text', ''), [{ text: 'plain text', highlighted: false }])
+
+console.log('highlight-match tests passed')

--- a/src/components/common/GlobalSearch.tsx
+++ b/src/components/common/GlobalSearch.tsx
@@ -27,7 +27,7 @@ function HighlightMatch({ text, query }: { text: string; query: string }) {
     <>
       {getHighlightParts(text, query).map((part, index) =>
         part.highlighted ? (
-          <mark key={`${part.text}-${index}`} className="bg-np-yellow/40 text-np-text-primary rounded px-0.5">
+          <mark key={`${part.text}-${index}`} className="page-search-highlight text-np-text-primary rounded px-0.5">
             {part.text}
           </mark>
         ) : (
@@ -199,7 +199,8 @@ export function GlobalSearch({ isOpen, onClose }: GlobalSearchProps) {
     return searchResults
   }, [debouncedQuery, notes, tasks, habits, journalEntries, bookmarks])
 
-  const highlightQuery = debouncedQuery.trim().startsWith('#')
+  const isTagSearch = debouncedQuery.trim().toLowerCase().startsWith('#')
+  const highlightQuery = isTagSearch
     ? debouncedQuery.trim().slice(1)
     : debouncedQuery
 
@@ -339,7 +340,7 @@ export function GlobalSearch({ isOpen, onClose }: GlobalSearchProps) {
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2">
                     <span className="text-np-text-primary truncate">
-                      <HighlightMatch text={result.title} query={highlightQuery} />
+                      <HighlightMatch text={result.title} query={isTagSearch ? '' : highlightQuery} />
                     </span>
                     <span className={`text-xs px-1.5 py-0.5 ${getTypeColor(result.type)} bg-np-bg-tertiary`}>
                       {result.type}
@@ -347,12 +348,12 @@ export function GlobalSearch({ isOpen, onClose }: GlobalSearchProps) {
                   </div>
                   {result.preview && (
                     <div className="text-xs text-np-text-secondary truncate mt-0.5">
-                      <HighlightMatch text={result.preview} query={highlightQuery} />
+                      <HighlightMatch text={result.preview} query={isTagSearch ? '' : highlightQuery} />
                     </div>
                   )}
                   <div className="flex items-center gap-2 mt-1">
                     {result.tags?.map((tag) => (
-                      <span key={tag} className="text-xs text-np-purple">#{tag}</span>
+                      <span key={tag} className="text-xs text-np-purple">#{isTagSearch ? <HighlightMatch text={tag} query={highlightQuery} /> : tag}</span>
                     ))}
                     {result.meta && (
                       <span className="text-xs text-np-text-secondary">{result.meta}</span>

--- a/src/components/common/GlobalSearch.tsx
+++ b/src/components/common/GlobalSearch.tsx
@@ -5,6 +5,7 @@ import { useHabitStore } from '../../stores/habitStore'
 import { useJournalStore } from '../../stores/journalStore'
 import { useBookmarkStore } from '../../stores/bookmarkStore'
 import { useUIStore } from '../../stores/uiStore'
+import { getHighlightParts } from './highlightMatch'
 
 interface SearchResult {
   id: string
@@ -19,6 +20,22 @@ interface SearchResult {
 interface GlobalSearchProps {
   isOpen: boolean
   onClose: () => void
+}
+
+function HighlightMatch({ text, query }: { text: string; query: string }) {
+  return (
+    <>
+      {getHighlightParts(text, query).map((part, index) =>
+        part.highlighted ? (
+          <mark key={`${part.text}-${index}`} className="bg-np-yellow/40 text-np-text-primary rounded px-0.5">
+            {part.text}
+          </mark>
+        ) : (
+          <span key={`${part.text}-${index}`}>{part.text}</span>
+        ),
+      )}
+    </>
+  )
 }
 
 export function GlobalSearch({ isOpen, onClose }: GlobalSearchProps) {
@@ -182,6 +199,10 @@ export function GlobalSearch({ isOpen, onClose }: GlobalSearchProps) {
     return searchResults
   }, [debouncedQuery, notes, tasks, habits, journalEntries, bookmarks])
 
+  const highlightQuery = debouncedQuery.trim().startsWith('#')
+    ? debouncedQuery.trim().slice(1)
+    : debouncedQuery
+
   // Debounce search query
   useEffect(() => {
     const debounceTimer = setTimeout(() => {
@@ -317,14 +338,16 @@ export function GlobalSearch({ isOpen, onClose }: GlobalSearchProps) {
                 </span>
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2">
-                    <span className="text-np-text-primary truncate">{result.title}</span>
+                    <span className="text-np-text-primary truncate">
+                      <HighlightMatch text={result.title} query={highlightQuery} />
+                    </span>
                     <span className={`text-xs px-1.5 py-0.5 ${getTypeColor(result.type)} bg-np-bg-tertiary`}>
                       {result.type}
                     </span>
                   </div>
                   {result.preview && (
                     <div className="text-xs text-np-text-secondary truncate mt-0.5">
-                      {result.preview}
+                      <HighlightMatch text={result.preview} query={highlightQuery} />
                     </div>
                   )}
                   <div className="flex items-center gap-2 mt-1">

--- a/src/components/common/PageSearch.tsx
+++ b/src/components/common/PageSearch.tsx
@@ -88,7 +88,7 @@ export function PageSearch({ isOpen, onClose }: PageSearchProps) {
         // Add highlighted match
         const highlight = document.createElement('mark')
         highlight.textContent = text.slice(matchStart, matchEnd)
-        highlight.className = 'bg-np-yellow/40 text-np-text-primary px-0.5 rounded page-search-highlight'
+        highlight.className = 'text-np-text-primary px-0.5 rounded page-search-highlight'
         highlight.dataset.matchIndex = String(matchCount)
         highlightedElements.current.push(highlight)
         fragment.appendChild(highlight)

--- a/src/components/common/highlightMatch.d.mts
+++ b/src/components/common/highlightMatch.d.mts
@@ -1,0 +1,6 @@
+export interface HighlightPart {
+  text: string;
+  highlighted: boolean;
+}
+
+export function getHighlightParts(text: string, query: string): HighlightPart[];

--- a/src/components/common/highlightMatch.mjs
+++ b/src/components/common/highlightMatch.mjs
@@ -1,0 +1,28 @@
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function getHighlightParts(text, query) {
+  const normalizedQuery = query.trim().replace(/^#/, "");
+  if (!normalizedQuery) return [{ text, highlighted: false }];
+
+  const matcher = new RegExp(escapeRegExp(normalizedQuery), "gi");
+  const parts = [];
+  let cursor = 0;
+
+  for (const match of text.matchAll(matcher)) {
+    const start = match.index ?? 0;
+    const matchedText = match[0];
+    if (start > cursor) {
+      parts.push({ text: text.slice(cursor, start), highlighted: false });
+    }
+    parts.push({ text: matchedText, highlighted: true });
+    cursor = start + matchedText.length;
+  }
+
+  if (cursor < text.length) {
+    parts.push({ text: text.slice(cursor), highlighted: false });
+  }
+
+  return parts.length > 0 ? parts : [{ text, highlighted: false }];
+}

--- a/src/components/common/highlightMatch.ts
+++ b/src/components/common/highlightMatch.ts
@@ -1,33 +1,10 @@
+import { getHighlightParts as getRuntimeHighlightParts } from './highlightMatch.mjs'
+
 export interface HighlightPart {
   text: string
   highlighted: boolean
 }
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-}
-
 export function getHighlightParts(text: string, query: string): HighlightPart[] {
-  const normalizedQuery = query.trim().replace(/^#/, '')
-  if (!normalizedQuery) return [{ text, highlighted: false }]
-
-  const matcher = new RegExp(escapeRegExp(normalizedQuery), 'gi')
-  const parts: HighlightPart[] = []
-  let cursor = 0
-
-  for (const match of text.matchAll(matcher)) {
-    const start = match.index ?? 0
-    const matchedText = match[0]
-    if (start > cursor) {
-      parts.push({ text: text.slice(cursor, start), highlighted: false })
-    }
-    parts.push({ text: matchedText, highlighted: true })
-    cursor = start + matchedText.length
-  }
-
-  if (cursor < text.length) {
-    parts.push({ text: text.slice(cursor), highlighted: false })
-  }
-
-  return parts.length > 0 ? parts : [{ text, highlighted: false }]
+  return getRuntimeHighlightParts(text, query) as HighlightPart[]
 }

--- a/src/components/common/highlightMatch.ts
+++ b/src/components/common/highlightMatch.ts
@@ -1,0 +1,33 @@
+export interface HighlightPart {
+  text: string
+  highlighted: boolean
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+export function getHighlightParts(text: string, query: string): HighlightPart[] {
+  const normalizedQuery = query.trim().replace(/^#/, '')
+  if (!normalizedQuery) return [{ text, highlighted: false }]
+
+  const matcher = new RegExp(escapeRegExp(normalizedQuery), 'gi')
+  const parts: HighlightPart[] = []
+  let cursor = 0
+
+  for (const match of text.matchAll(matcher)) {
+    const start = match.index ?? 0
+    const matchedText = match[0]
+    if (start > cursor) {
+      parts.push({ text: text.slice(cursor, start), highlighted: false })
+    }
+    parts.push({ text: matchedText, highlighted: true })
+    cursor = start + matchedText.length
+  }
+
+  if (cursor < text.length) {
+    parts.push({ text: text.slice(cursor), highlighted: false })
+  }
+
+  return parts.length > 0 ? parts : [{ text, highlighted: false }]
+}

--- a/src/index.css
+++ b/src/index.css
@@ -27,6 +27,7 @@
   --accent-purple: #C586C0;
   --accent-yellow: #DCDCAA;
   --accent-cyan: #4EC9B0;
+  --highlight-bg: #5C5A00;
 
   /* Status Colors */
   --success: #4EC9B0;
@@ -56,6 +57,7 @@
   --accent-purple: #AF00DB;
   --accent-yellow: #795E26;
   --accent-cyan: #267F99;
+  --highlight-bg: #FFF3A6;
 
   /* Status Colors */
   --success: #008000;
@@ -210,4 +212,8 @@ body {
 }
 .app-no-drag {
   -webkit-app-region: no-drag;
+}
+
+.page-search-highlight {
+  background-color: var(--highlight-bg);
 }


### PR DESCRIPTION
## What changed

Global search results now show which part of the title or preview matched the query.

- Added a small `getHighlightParts` helper that escapes regex characters, matches case-insensitively, preserves repeated matches, and strips the leading `#` used by tag searches.
- Rendered matched segments as theme-aware `<mark>` elements in result titles and previews.
- Added focused helper coverage for repeated matches, regex characters, no-match input, tag queries, and empty queries.

## Validation

- `npm run test:highlight` passed.
- `npm run build` passed.
- Changed-file ESLint passed.
- The repository-wide `npm run lint` remains blocked by 28 pre-existing errors in unrelated Electron and store files.

The search result filtering and tag-search behavior remain unchanged; this only improves the result rendering.